### PR TITLE
Get off the snapshot build of kotlinpoet as stable version launched

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
             'junit' : '4.12',
             'junitImplementation' : '1.1.1',
             'kotlin': '1.3.72',
-            'kotlinPoet': '1.6.0-SNAPSHOT',
+            'kotlinPoet': '1.6.0',
             'ktx': '1.1.0',
             'lifecycle':'2.2.0',
             'picasso': '2.71828',
@@ -73,7 +73,6 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     // Needed due to kotlin bug that is fixed in Kotlin 1.4. Since Compose doesn't yet work with 1.4, 


### PR DESCRIPTION
Resolves #34 