### PR TITLE
Use Jetpack Navigation for handling navigations across the Showkase Browser App

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
             'androidXTestRules':'1.1.0',
             'assertJ': '3.16.1',
             'compose': '1.0.0-alpha06',
+            'composeNavigation': '1.0.0-alpha01',
             'detekt': '1.7.4',
             'espresso': '3.2.0',
             'gradle': '4.2.0-alpha15',
@@ -27,6 +28,7 @@ buildscript {
             'autoService': "com.google.auto.service:auto-service:${versions.autoService}",
             'compose': [
                     'composeComplier': "androidx.compose:compose-compiler:${versions.compose}",
+                    'composeNavigation': "androidx.navigation:navigation-compose:${versions.composeNavigation}",
                     'composeRuntime': "androidx.compose.runtime:runtime:${versions.compose}",
                     'core': "androidx.compose.ui:ui:${versions.compose}",
                     'foundation': "androidx.compose.foundation:foundation:${versions.compose}",

--- a/sample/src/main/java/com/airbnb/android/showkasesample/ShowkaseTheme.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/ShowkaseTheme.kt
@@ -9,9 +9,7 @@ import androidx.compose.ui.res.colorResource
 
 @Composable
 fun ShowkaseTheme(children: @Composable()() -> Unit) {
-    val light = lightColors(
-        error = colorResource(id = R.color.purple200)
-    )
+    val light = lightColors()
     val dark = darkColors()
     val colors = if (isSystemInDarkTheme()) { dark } else { light }
     MaterialTheme(colors = colors) {

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     
     // Compose
     implementation deps.compose.composeRuntime
+    implementation deps.compose.composeNavigation
     implementation deps.compose.core
     implementation deps.compose.foundation
     implementation deps.compose.tooling

--- a/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
@@ -1,6 +1,8 @@
 package com.airbnb.android.showkase.models
 
+import android.util.Log
 import androidx.compose.runtime.MutableState
+import androidx.navigation.NavHostController
 
 internal enum class ShowkaseCurrentScreen {
     COMPONENT_GROUPS,
@@ -13,13 +15,12 @@ internal enum class ShowkaseCurrentScreen {
     TYPOGRAPHY_IN_A_GROUP,
 }
 
-internal fun ShowkaseCurrentScreen.insideGroup() =
-    this == ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP ||
-            this == ShowkaseCurrentScreen.COLORS_IN_A_GROUP ||
-            this == ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP
+internal fun String?.insideGroup() =
+    this == ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name ||
+            this == ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name ||
+            this == ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name
 
 internal data class ShowkaseBrowserScreenMetadata(
-    val currentScreen: ShowkaseCurrentScreen = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES,
     val currentGroup: String? = null,
     val currentComponent: String? = null,
     val isSearchActive: Boolean = false,
@@ -27,6 +28,7 @@ internal data class ShowkaseBrowserScreenMetadata(
 )
 
 internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
+    Log.e("Clearing Search", "Clearing Search")
     update {
         copy(
             isSearchActive = false,
@@ -37,4 +39,5 @@ internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
 
 internal fun <T> MutableState<T>.update(block: T.() -> T) {
     value = this.component1().run(block)
+    Log.e("Metadat value", value.toString())
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
@@ -25,6 +25,17 @@ internal data class ShowkaseBrowserScreenMetadata(
     val searchQuery: String? = null,
 )
 
+internal fun MutableState<ShowkaseBrowserScreenMetadata>.clear() {
+    update {
+        copy(
+            isSearchActive = false,
+            searchQuery = null,
+            currentComponent = null,
+            currentGroup = null
+        )
+    }
+}
+
 internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
     update {
         copy(

--- a/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
@@ -1,8 +1,6 @@
 package com.airbnb.android.showkase.models
 
-import android.util.Log
 import androidx.compose.runtime.MutableState
-import androidx.navigation.NavHostController
 
 internal enum class ShowkaseCurrentScreen {
     COMPONENT_GROUPS,
@@ -28,7 +26,6 @@ internal data class ShowkaseBrowserScreenMetadata(
 )
 
 internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
-    Log.e("Clearing Search", "Clearing Search")
     update {
         copy(
             isSearchActive = false,
@@ -39,5 +36,4 @@ internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
 
 internal fun <T> MutableState<T>.update(block: T.() -> T) {
     value = this.component1().run(block)
-    Log.e("Metadat value", value.toString())
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
@@ -49,15 +49,11 @@ internal fun handler(
 
 @Composable
 internal fun BackButtonHandler(
-    navController: NavHostController,
     onBackPressed: () -> Unit, 
 ) {
     var context = ContextAmbient.current
     while (context is ContextWrapper) {
         if (context is OnBackPressedDispatcherOwner) {
-            navController.setOnBackPressedDispatcher(
-                (context as OnBackPressedDispatcherOwner).onBackPressedDispatcher
-            )
             break
         }
         context = context.baseContext

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
@@ -4,15 +4,12 @@ import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcherOwner
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Providers
 import androidx.compose.runtime.onCommit
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticAmbientOf
 import androidx.compose.ui.platform.ContextAmbient
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
-import androidx.navigation.NavHostController
 
 /**
  * Related discussion - 
@@ -52,6 +49,11 @@ internal fun BackButtonHandler(
     onBackPressed: () -> Unit, 
 ) {
     var context = ContextAmbient.current
+    // Inspired from https://cs.android.com/androidx/platform/frameworks/support/+/
+    // androidx-master-dev:navigation/navigation-compose/src/main/java/androidx/navigation/
+    // compose/NavHost.kt;l=88
+    // This was necessary because using Jetpack Navigation does not allow typecasting a 
+    // NavBackStackEntry to LifecycleOwnerAmbient.
     while (context is ContextWrapper) {
         if (context is OnBackPressedDispatcherOwner) {
             break

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
@@ -1,14 +1,18 @@
 package com.airbnb.android.showkase.ui
 
+import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcherOwner
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Providers
 import androidx.compose.runtime.onCommit
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticAmbientOf
+import androidx.compose.ui.platform.ContextAmbient
 import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.navigation.NavHostController
 
 /**
  * Related discussion - 
@@ -44,9 +48,22 @@ internal fun handler(
 }
 
 @Composable
-internal fun BackButtonHandler(onBackPressed: () -> Unit) {
+internal fun BackButtonHandler(
+    navController: NavHostController,
+    onBackPressed: () -> Unit, 
+) {
+    var context = ContextAmbient.current
+    while (context is ContextWrapper) {
+        if (context is OnBackPressedDispatcherOwner) {
+            navController.setOnBackPressedDispatcher(
+                (context as OnBackPressedDispatcherOwner).onBackPressedDispatcher
+            )
+            break
+        }
+        context = context.baseContext
+    }
     Providers(
-        AmbientBackPressedDispatcher provides LifecycleOwnerAmbient.current as ComponentActivity
+        AmbientBackPressedDispatcher provides context as ComponentActivity
     ) {
         handler {
             onBackPressed()

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.KEY_ROUTE
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.navigate
 import androidx.navigation.compose.rememberNavController
 import com.airbnb.android.showkase.R
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
@@ -232,3 +233,9 @@ internal fun ShowkaseBodyContent(
         }
     }
 }
+
+/**
+ * Helper function to navigate to the passed [ShowkaseCurrentScreen]
+ */
+internal fun NavHostController.navigate(destinationScreen: ShowkaseCurrentScreen) = 
+    navigate(destinationScreen.name)

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,11 +1,12 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.compose.material.Icon
+import android.util.Log
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.TextField
@@ -14,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ContextAmbient
@@ -22,6 +24,12 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.KEY_ROUTE
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import com.airbnb.android.showkase.R
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
@@ -37,17 +45,21 @@ internal fun ShowkaseBrowserApp(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
+    val navController = rememberNavController()
     Scaffold(
         drawerContent = null,
         topBar = {
-            ShowkaseAppBar(showkaseBrowserScreenMetadata)
+            ShowkaseAppBar(navController, showkaseBrowserScreenMetadata)
         },
         bodyContent = {
             Column(
                 modifier = Modifier.fillMaxSize().background(color = SHOWKASE_COLOR_BACKGROUND),
             ) {
                 ShowkaseBodyContent(
-                    groupedComponentMap, groupedColorsMap, groupedTypographyMap,
+                    navController,
+                    groupedComponentMap, 
+                    groupedColorsMap, 
+                    groupedTypographyMap,
                     showkaseBrowserScreenMetadata
                 )
             }
@@ -56,40 +68,48 @@ internal fun ShowkaseBrowserApp(
 }
 
 @Composable
-internal fun ShowkaseAppBar(showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+internal fun ShowkaseAppBar(
+    navController: NavHostController,
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.arguments?.getString(KEY_ROUTE)
     TopAppBar(
         title = {
-            ShowkaseAppBarTitle(showkaseBrowserScreenMetadata)
+            ShowkaseAppBarTitle(showkaseBrowserScreenMetadata, currentRoute)
         },
         actions = {
-            ShowkaseAppBarActions(showkaseBrowserScreenMetadata)
+            ShowkaseAppBarActions(showkaseBrowserScreenMetadata, currentRoute)
         },
         backgroundColor = Color.White
     )
 }
 
 @Composable
-private fun ShowkaseAppBarTitle(metadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun ShowkaseAppBarTitle(
+    metadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    currentRoute: String?
+) {
     when {
         metadata.value.isSearchActive -> {
             ShowkaseSearchField(metadata)
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
+        currentRoute == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name -> {
             Text(ContextAmbient.current.getString(R.string.app_name))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.components_category))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COLOR_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.COLOR_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.colors_category))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.typography_category))
         }
-        metadata.value.currentScreen.insideGroup() -> {
+        currentRoute.insideGroup() -> {
             Text(metadata.value.currentGroup.orEmpty())
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_DETAIL -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_DETAIL.name -> {
             Text(metadata.value.currentComponent.orEmpty())
         }
     }
@@ -121,18 +141,22 @@ internal fun ShowkaseSearchField(metadata: MutableState<ShowkaseBrowserScreenMet
 }
 
 @Composable
-private fun ShowkaseAppBarActions(metadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun ShowkaseAppBarActions(
+    metadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    currentRoute: String?
+) {
     when {
         metadata.value.isSearchActive -> {
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_DETAIL ||
-                metadata.value.currentScreen == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_DETAIL.name ||
+                currentRoute == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name -> {
         }
         else -> {
             IconButton(
                 modifier = Modifier.testTag("SearchIcon"),
                 onClick = {
                     metadata.value = metadata.value.copy(isSearchActive = true)
+                    Log.e("Metadata updated search", metadata.value.toString())
                 }
             ) {
                 Icon(asset = Icons.Filled.Search)
@@ -143,55 +167,69 @@ private fun ShowkaseAppBarActions(metadata: MutableState<ShowkaseBrowserScreenMe
 
 @Composable
 internal fun ShowkaseBodyContent(
+    navController: NavHostController,
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
-    when (showkaseBrowserScreenMetadata.value.currentScreen) {
-        ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
-            ShowkaseCategoriesScreen(showkaseBrowserScreenMetadata)
+    NavHost(
+        navController = navController,
+        startDestination = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name
+    ) {
+        composable(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name) {
+            ShowkaseCategoriesScreen(
+                showkaseBrowserScreenMetadata, 
+                navController
+            )
         }
-        ShowkaseCurrentScreen.COMPONENT_GROUPS -> {
+        composable(ShowkaseCurrentScreen.COMPONENT_GROUPS.name) {
             ShowkaseComponentGroupsScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name) {
             ShowkaseComponentsInAGroupScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata, 
+                navController
             )
         }
-        ShowkaseCurrentScreen.COMPONENT_DETAIL -> {
+        composable(ShowkaseCurrentScreen.COMPONENT_DETAIL.name) {
             ShowkaseComponentDetailScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COLOR_GROUPS -> {
+        composable(ShowkaseCurrentScreen.COLOR_GROUPS.name) {
             ShowkaseColorGroupsScreen(
                 groupedColorsMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COLORS_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name) {
             ShowkaseColorsInAGroupScreen(
                 groupedColorsMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS -> {
+        composable(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name) {
             ShowkaseTypographyGroupsScreen(
                 groupedTypographyMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name) {
             ShowkaseTypographyInAGroupScreen(
                 groupedTypographyMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
     }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,6 +1,5 @@
 package com.airbnb.android.showkase.ui
 
-import android.util.Log
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -156,7 +155,6 @@ private fun ShowkaseAppBarActions(
                 modifier = Modifier.testTag("SearchIcon"),
                 onClick = {
                     metadata.value = metadata.value.copy(isSearchActive = true)
-                    Log.e("Metadata updated search", metadata.value.toString())
                 }
             ) {
                 Icon(asset = Icons.Filled.Search)

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCategory
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 import java.util.Locale
@@ -72,14 +73,7 @@ internal fun goBackToCategoriesScreen(
             showkaseBrowserScreenMetadata.clearActiveSearch()
         }
         else ->  {
-            showkaseBrowserScreenMetadata.update {
-                copy(
-                    currentComponent = null,
-                    isSearchActive = false,
-                    searchQuery = null,
-                    currentGroup = null
-                )
-            }
+            showkaseBrowserScreenMetadata.clear()
             navHostController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name)
         }
     }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -1,10 +1,13 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.activity.ComponentActivity
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.compose.ui.platform.ContextAmbient
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCategory
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -14,10 +17,10 @@ import java.util.Locale
 
 @Composable
 internal fun ShowkaseCategoriesScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navHostController: NavHostController
 ) {
-    val activity = (LifecycleOwnerAmbient.current as ComponentActivity)
-    
+    val activity = ContextAmbient.current as  AppCompatActivity
     LazyColumnFor(items = ShowkaseCategory.values().toList()) { category ->
         val defaultlLocale = Locale.getDefault()
         SimpleTextCard(
@@ -25,26 +28,32 @@ internal fun ShowkaseCategoriesScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = when(category) {
-                            ShowkaseCategory.COMPONENTS -> ShowkaseCurrentScreen.COMPONENT_GROUPS
-                            ShowkaseCategory.COLORS -> ShowkaseCurrentScreen.COLOR_GROUPS
-                            ShowkaseCategory.TYPOGRAPHY -> ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS
-                        },
                         currentGroup = null,
                         isSearchActive = false,
                         searchQuery = null
                     )
                 }
+                when(category) {
+                    ShowkaseCategory.COMPONENTS -> navHostController.navigate(
+                        ShowkaseCurrentScreen.COMPONENT_GROUPS.name
+                    )
+                    ShowkaseCategory.COLORS -> navHostController.navigate(
+                        ShowkaseCurrentScreen.COLOR_GROUPS.name
+                    )
+                    ShowkaseCategory.TYPOGRAPHY -> navHostController.navigate(
+                        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name
+                    )
+                }
             }
         )
     }
-    BackButtonHandler {
+    BackButtonHandler(navHostController) {
         goBackFromCategoriesScreen(activity, showkaseBrowserScreenMetadata)
     }
 }
 
 private fun goBackFromCategoriesScreen(
-    activity: ComponentActivity,
+    activity: AppCompatActivity,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
@@ -55,19 +64,26 @@ private fun goBackFromCategoriesScreen(
 }
 
 internal fun goBackToCategoriesScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navHostController: NavHostController
 ) {
-    val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
+    
     when {
-        isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null,
-                currentGroup = null
-            )
+        showkaseBrowserScreenMetadata.value.isSearchActive -> {
+            showkaseBrowserScreenMetadata.clearActiveSearch()
+            Log.e("goBackToCategories clear", showkaseBrowserScreenMetadata.toString())
+        }
+        else ->  {
+            showkaseBrowserScreenMetadata.update {
+                copy(
+                    currentComponent = null,
+                    isSearchActive = false,
+                    searchQuery = null,
+                    currentGroup = null
+                )
+            }
+            Log.e("goBackToCategories else", showkaseBrowserScreenMetadata.toString())
+            navHostController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 @Composable
 internal fun ShowkaseCategoriesScreen(
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
-    navHostController: NavHostController
+    navController: NavHostController
 ) {
     val activity = ContextAmbient.current as  AppCompatActivity
     LazyColumnFor(items = ShowkaseCategory.values().toList()) { category ->
@@ -34,14 +34,14 @@ internal fun ShowkaseCategoriesScreen(
                     )
                 }
                 when(category) {
-                    ShowkaseCategory.COMPONENTS -> navHostController.navigate(
-                        ShowkaseCurrentScreen.COMPONENT_GROUPS.name
+                    ShowkaseCategory.COMPONENTS -> navController.navigate(
+                        ShowkaseCurrentScreen.COMPONENT_GROUPS
                     )
-                    ShowkaseCategory.COLORS -> navHostController.navigate(
-                        ShowkaseCurrentScreen.COLOR_GROUPS.name
+                    ShowkaseCategory.COLORS -> navController.navigate(
+                        ShowkaseCurrentScreen.COLOR_GROUPS
                     )
-                    ShowkaseCategory.TYPOGRAPHY -> navHostController.navigate(
-                        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name
+                    ShowkaseCategory.TYPOGRAPHY -> navController.navigate(
+                        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS
                     )
                 }
             }
@@ -65,7 +65,7 @@ private fun goBackFromCategoriesScreen(
 
 internal fun goBackToCategoriesScreen(
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
-    navHostController: NavHostController
+    navController: NavHostController
 ) {
     
     when {
@@ -74,7 +74,7 @@ internal fun goBackToCategoriesScreen(
         }
         else ->  {
             showkaseBrowserScreenMetadata.clear()
-            navHostController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name)
+            navController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -47,7 +47,7 @@ internal fun ShowkaseCategoriesScreen(
             }
         )
     }
-    BackButtonHandler(navHostController) {
+    BackButtonHandler {
         goBackFromCategoriesScreen(activity, showkaseBrowserScreenMetadata)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -1,6 +1,5 @@
 package com.airbnb.android.showkase.ui
 
-import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
@@ -71,7 +70,6 @@ internal fun goBackToCategoriesScreen(
     when {
         showkaseBrowserScreenMetadata.value.isSearchActive -> {
             showkaseBrowserScreenMetadata.clearActiveSearch()
-            Log.e("goBackToCategories clear", showkaseBrowserScreenMetadata.toString())
         }
         else ->  {
             showkaseBrowserScreenMetadata.update {
@@ -82,7 +80,6 @@ internal fun goBackToCategoriesScreen(
                     currentGroup = null
                 )
             }
-            Log.e("goBackToCategories else", showkaseBrowserScreenMetadata.toString())
             navHostController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name)
         }
     }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
@@ -35,7 +35,7 @@ internal fun ShowkaseColorGroupsScreen(
             }
         )
     })
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
@@ -31,7 +31,7 @@ internal fun ShowkaseColorGroupsScreen(
                         searchQuery = null
                     ) 
                 }
-                navController.navigate(ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name)
+                navController.navigate(ShowkaseCurrentScreen.COLORS_IN_A_GROUP)
             }
         )
     })

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
@@ -3,6 +3,8 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -11,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseColorGroupsScreen(
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedColorsMap.keys.sorted(),
@@ -23,16 +26,16 @@ internal fun ShowkaseColorGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.COLORS_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     ) 
                 }
+                navController.navigate(ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name)
             }
         )
     })
-    BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 
@@ -85,14 +86,7 @@ private fun  goBackFromColorsInAGroupScreen(
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
-            showkaseBrowserScreenMetadata.update {
-                copy(
-                    currentComponent = null,
-                    isSearchActive = false,
-                    searchQuery = null,
-                    currentGroup = null
-                )
-            }
+            showkaseBrowserScreenMetadata.clear()
             navController.navigate(ShowkaseCurrentScreen.COLOR_GROUPS.name)
         }
     }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -87,7 +87,7 @@ private fun  goBackFromColorsInAGroupScreen(
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
             showkaseBrowserScreenMetadata.clear()
-            navController.navigate(ShowkaseCurrentScreen.COLOR_GROUPS.name)
+            navController.navigate(ShowkaseCurrentScreen.COLOR_GROUPS)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -72,7 +72,7 @@ internal fun ShowkaseColorsInAGroupScreen(
             }
         }
     )
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackFromColorsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -29,7 +31,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseColorsInAGroupScreen(
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupColorsList =
         groupedColorsMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -69,25 +72,28 @@ internal fun ShowkaseColorsInAGroupScreen(
             }
         }
     )
-    BackButtonHandler {
-        goBackFromColorsInAGroupScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackFromColorsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun  goBackFromColorsInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.COLOR_GROUPS,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null,
-                currentGroup = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.update {
+                copy(
+                    currentComponent = null,
+                    isSearchActive = false,
+                    searchQuery = null,
+                    currentGroup = null
+                )
+            }
+            navController.navigate(ShowkaseCurrentScreen.COLOR_GROUPS.name)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -82,7 +82,7 @@ internal fun ShowkaseComponentDetailScreen(
             }
         }
     })
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         back(showkaseBrowserScreenMetadata, navController)
     }
     

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.R
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
@@ -53,7 +55,8 @@ import java.util.Locale
 @Composable
 internal fun ShowkaseComponentDetailScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val componentMetadataList =
         groupedComponentMap[showkaseBrowserScreenMetadata.value.currentGroup] ?: return
@@ -79,8 +82,8 @@ internal fun ShowkaseComponentDetailScreen(
             }
         }
     })
-    BackButtonHandler {
-        back(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        back(showkaseBrowserScreenMetadata, navController)
     }
     
 }
@@ -202,13 +205,16 @@ internal fun generateComposableModifier(metadata: ShowkaseBrowserComponent): Mod
     }
 }
 
-private fun back(showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun back(
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
+) {
     showkaseBrowserScreenMetadata.update {
         copy(
-            currentScreen = ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP,
             currentComponent = null,
             isSearchActive = false,
             searchQuery = null
         )
     }
+    navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name)
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -216,5 +216,5 @@ private fun back(
             searchQuery = null
         )
     }
-    navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name)
+    navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP)
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
@@ -36,7 +36,7 @@ internal fun ShowkaseComponentGroupsScreen(
             }
         )
     })
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
@@ -32,7 +32,7 @@ internal fun ShowkaseComponentGroupsScreen(
                         searchQuery = null
                     )
                 }
-                navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name)
+                navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP)
             }
         )
     })

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
@@ -1,10 +1,10 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -13,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseComponentGroupsScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedComponentMap.keys.sorted(),
@@ -26,17 +27,17 @@ internal fun ShowkaseComponentGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     )
                 }
+                navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name)
             }
         )
     })
-    BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
@@ -40,7 +40,7 @@ internal fun ShowkaseComponentsInAGroupScreen(
             )
         }
     )
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackFromComponentsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
@@ -36,7 +36,7 @@ internal fun ShowkaseComponentsInAGroupScreen(
                             isSearchActive = false
                         )
                     }
-                    navController.navigate(ShowkaseCurrentScreen.COMPONENT_DETAIL.name)
+                    navController.navigate(ShowkaseCurrentScreen.COMPONENT_DETAIL)
                 }
             )
         }
@@ -55,7 +55,7 @@ private fun goBackFromComponentsInAGroupScreen(
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
             showkaseBrowserScreenMetadata.clear()
-            navController.navigate(ShowkaseCurrentScreen.COMPONENT_GROUPS.name)
+            navController.navigate(ShowkaseCurrentScreen.COMPONENT_GROUPS)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 
@@ -53,14 +54,7 @@ private fun goBackFromComponentsInAGroupScreen(
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
-            showkaseBrowserScreenMetadata.update {
-                copy(
-                    currentGroup = null,
-                    currentComponent = null,
-                    isSearchActive = false,
-                    searchQuery = null
-                )
-            }
+            showkaseBrowserScreenMetadata.clear()
             navController.navigate(ShowkaseCurrentScreen.COMPONENT_GROUPS.name)
         }
     }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
@@ -3,6 +3,8 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -12,7 +14,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseComponentsInAGroupScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupComponentsList =
         groupedComponentMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -28,34 +31,37 @@ internal fun ShowkaseComponentsInAGroupScreen(
                 onClick = {
                     showkaseBrowserScreenMetadata.update {
                         copy(
-                            currentScreen = ShowkaseCurrentScreen.COMPONENT_DETAIL,
                             currentComponent = groupComponent.componentName,
                             isSearchActive = false
                         )
                     }
+                    navController.navigate(ShowkaseCurrentScreen.COMPONENT_DETAIL.name)
                 }
             )
         }
     )
-    BackButtonHandler {
-        goBackFromComponentsInAGroupScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackFromComponentsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun goBackFromComponentsInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.COMPONENT_GROUPS,
-                currentGroup = null,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.update {
+                copy(
+                    currentGroup = null,
+                    currentComponent = null,
+                    isSearchActive = false,
+                    searchQuery = null
+                )
+            }
+            navController.navigate(ShowkaseCurrentScreen.COMPONENT_GROUPS.name)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
@@ -36,7 +36,7 @@ internal fun ShowkaseTypographyGroupsScreen(
             }
         )
     })
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
@@ -3,6 +3,8 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -11,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseTypographyGroupsScreen(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedTypographyMap.keys.sorted(),
@@ -24,16 +27,16 @@ internal fun ShowkaseTypographyGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     )
                 }
+                navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name)
             }
         )
     })
-    BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
@@ -32,7 +32,7 @@ internal fun ShowkaseTypographyGroupsScreen(
                         searchQuery = null
                     )
                 }
-                navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name)
+                navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP)
             }
         )
     })

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
@@ -45,7 +45,7 @@ internal fun ShowkaseTypographyInAGroupScreen(
             Divider()
         }
     )
-    BackButtonHandler(navController) {
+    BackButtonHandler {
         goBackFromTypographyInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
@@ -60,7 +60,7 @@ private fun goBackFromTypographyInAGroupScreen(
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
             showkaseBrowserScreenMetadata.clear()
-            navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name)
+            navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
@@ -11,9 +11,8 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.scrollBy
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -24,7 +23,8 @@ import java.util.Locale
 @Composable
 internal fun ShowkaseTypographyInAGroupScreen(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupTypographyList =
         groupedTypographyMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -45,25 +45,28 @@ internal fun ShowkaseTypographyInAGroupScreen(
             Divider()
         }
     )
-    BackButtonHandler {
-        goBackFromTypographyInAGroupScreen(showkaseBrowserScreenMetadata)
+    BackButtonHandler(navController) {
+        goBackFromTypographyInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun goBackFromTypographyInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS,
-                currentGroup = null,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.update {
+                copy(
+                    currentGroup = null,
+                    currentComponent = null,
+                    isSearchActive = false,
+                    searchQuery = null
+                )
+            }
+            navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
@@ -16,6 +16,7 @@ import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 import java.util.Locale
@@ -58,14 +59,7 @@ private fun goBackFromTypographyInAGroupScreen(
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
         else -> {
-            showkaseBrowserScreenMetadata.update {
-                copy(
-                    currentGroup = null,
-                    currentComponent = null,
-                    isSearchActive = false,
-                    searchQuery = null
-                )
-            }
+            showkaseBrowserScreenMetadata.clear()
             navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name)
         }
     }


### PR DESCRIPTION
Compose alpha06 comes with Jetpack Navigation support. In this PR, I make use of that for doing navigation in the Showkase Browser App

@airbnb/showkase-maintainers 