### PR TITLE
[Cherry-Pick] Use Jetpack Navigation for handling navigations across the Showkase Browser App

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
             'androidXTestRules':'1.1.0',
             'assertJ': '3.16.1',
             'compose': '1.0.0-alpha06',
+            'composeNavigation': '1.0.0-alpha01',
             'detekt': '1.7.4',
             'espresso': '3.2.0',
             'gradle': '4.2.0-alpha15',
@@ -27,6 +28,7 @@ buildscript {
             'autoService': "com.google.auto.service:auto-service:${versions.autoService}",
             'compose': [
                     'composeComplier': "androidx.compose:compose-compiler:${versions.compose}",
+                    'composeNavigation': "androidx.navigation:navigation-compose:${versions.composeNavigation}",
                     'composeRuntime': "androidx.compose.runtime:runtime:${versions.compose}",
                     'core': "androidx.compose.ui:ui:${versions.compose}",
                     'foundation': "androidx.compose.foundation:foundation:${versions.compose}",

--- a/sample/src/main/java/com/airbnb/android/showkasesample/ShowkaseTheme.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/ShowkaseTheme.kt
@@ -9,9 +9,7 @@ import androidx.compose.ui.res.colorResource
 
 @Composable
 fun ShowkaseTheme(children: @Composable()() -> Unit) {
-    val light = lightColors(
-        error = colorResource(id = R.color.purple200)
-    )
+    val light = lightColors()
     val dark = darkColors()
     val colors = if (isSystemInDarkTheme()) { dark } else { light }
     MaterialTheme(colors = colors) {

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     
     // Compose
     implementation deps.compose.composeRuntime
+    implementation deps.compose.composeNavigation
     implementation deps.compose.core
     implementation deps.compose.foundation
     implementation deps.compose.tooling

--- a/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/models/ShowkaseBrowserScreenMetadata.kt
@@ -13,18 +13,28 @@ internal enum class ShowkaseCurrentScreen {
     TYPOGRAPHY_IN_A_GROUP,
 }
 
-internal fun ShowkaseCurrentScreen.insideGroup() =
-    this == ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP ||
-            this == ShowkaseCurrentScreen.COLORS_IN_A_GROUP ||
-            this == ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP
+internal fun String?.insideGroup() =
+    this == ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name ||
+            this == ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name ||
+            this == ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name
 
 internal data class ShowkaseBrowserScreenMetadata(
-    val currentScreen: ShowkaseCurrentScreen = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES,
     val currentGroup: String? = null,
     val currentComponent: String? = null,
     val isSearchActive: Boolean = false,
     val searchQuery: String? = null,
 )
+
+internal fun MutableState<ShowkaseBrowserScreenMetadata>.clear() {
+    update {
+        copy(
+            isSearchActive = false,
+            searchQuery = null,
+            currentComponent = null,
+            currentGroup = null
+        )
+    }
+}
 
 internal fun MutableState<ShowkaseBrowserScreenMetadata>.clearActiveSearch() {
     update {

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/BackButtonHandler.kt
@@ -1,5 +1,6 @@
 package com.airbnb.android.showkase.ui
 
+import android.content.ContextWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcherOwner
@@ -8,7 +9,7 @@ import androidx.compose.runtime.Providers
 import androidx.compose.runtime.onCommit
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticAmbientOf
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.compose.ui.platform.ContextAmbient
 
 /**
  * Related discussion - 
@@ -44,9 +45,23 @@ internal fun handler(
 }
 
 @Composable
-internal fun BackButtonHandler(onBackPressed: () -> Unit) {
+internal fun BackButtonHandler(
+    onBackPressed: () -> Unit, 
+) {
+    var context = ContextAmbient.current
+    // Inspired from https://cs.android.com/androidx/platform/frameworks/support/+/
+    // androidx-master-dev:navigation/navigation-compose/src/main/java/androidx/navigation/
+    // compose/NavHost.kt;l=88
+    // This was necessary because using Jetpack Navigation does not allow typecasting a 
+    // NavBackStackEntry to LifecycleOwnerAmbient.
+    while (context is ContextWrapper) {
+        if (context is OnBackPressedDispatcherOwner) {
+            break
+        }
+        context = context.baseContext
+    }
     Providers(
-        AmbientBackPressedDispatcher provides LifecycleOwnerAmbient.current as ComponentActivity
+        AmbientBackPressedDispatcher provides context as ComponentActivity
     ) {
         handler {
             onBackPressed()

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,11 +1,11 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.compose.material.Icon
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.TextField
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ContextAmbient
@@ -22,6 +23,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.KEY_ROUTE
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.navigate
+import androidx.navigation.compose.rememberNavController
 import com.airbnb.android.showkase.R
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
@@ -37,17 +45,21 @@ internal fun ShowkaseBrowserApp(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
+    val navController = rememberNavController()
     Scaffold(
         drawerContent = null,
         topBar = {
-            ShowkaseAppBar(showkaseBrowserScreenMetadata)
+            ShowkaseAppBar(navController, showkaseBrowserScreenMetadata)
         },
         bodyContent = {
             Column(
                 modifier = Modifier.fillMaxSize().background(color = SHOWKASE_COLOR_BACKGROUND),
             ) {
                 ShowkaseBodyContent(
-                    groupedComponentMap, groupedColorsMap, groupedTypographyMap,
+                    navController,
+                    groupedComponentMap, 
+                    groupedColorsMap, 
+                    groupedTypographyMap,
                     showkaseBrowserScreenMetadata
                 )
             }
@@ -56,40 +68,48 @@ internal fun ShowkaseBrowserApp(
 }
 
 @Composable
-internal fun ShowkaseAppBar(showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+internal fun ShowkaseAppBar(
+    navController: NavHostController,
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.arguments?.getString(KEY_ROUTE)
     TopAppBar(
         title = {
-            ShowkaseAppBarTitle(showkaseBrowserScreenMetadata)
+            ShowkaseAppBarTitle(showkaseBrowserScreenMetadata, currentRoute)
         },
         actions = {
-            ShowkaseAppBarActions(showkaseBrowserScreenMetadata)
+            ShowkaseAppBarActions(showkaseBrowserScreenMetadata, currentRoute)
         },
         backgroundColor = Color.White
     )
 }
 
 @Composable
-private fun ShowkaseAppBarTitle(metadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun ShowkaseAppBarTitle(
+    metadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    currentRoute: String?
+) {
     when {
         metadata.value.isSearchActive -> {
             ShowkaseSearchField(metadata)
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
+        currentRoute == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name -> {
             Text(ContextAmbient.current.getString(R.string.app_name))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.components_category))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COLOR_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.COLOR_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.colors_category))
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS -> {
+        currentRoute == ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name -> {
             Text(ContextAmbient.current.getString(R.string.typography_category))
         }
-        metadata.value.currentScreen.insideGroup() -> {
+        currentRoute.insideGroup() -> {
             Text(metadata.value.currentGroup.orEmpty())
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_DETAIL -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_DETAIL.name -> {
             Text(metadata.value.currentComponent.orEmpty())
         }
     }
@@ -121,12 +141,15 @@ internal fun ShowkaseSearchField(metadata: MutableState<ShowkaseBrowserScreenMet
 }
 
 @Composable
-private fun ShowkaseAppBarActions(metadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun ShowkaseAppBarActions(
+    metadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    currentRoute: String?
+) {
     when {
         metadata.value.isSearchActive -> {
         }
-        metadata.value.currentScreen == ShowkaseCurrentScreen.COMPONENT_DETAIL ||
-                metadata.value.currentScreen == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
+        currentRoute == ShowkaseCurrentScreen.COMPONENT_DETAIL.name ||
+                currentRoute == ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name -> {
         }
         else -> {
             IconButton(
@@ -143,56 +166,76 @@ private fun ShowkaseAppBarActions(metadata: MutableState<ShowkaseBrowserScreenMe
 
 @Composable
 internal fun ShowkaseBodyContent(
+    navController: NavHostController,
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
-    when (showkaseBrowserScreenMetadata.value.currentScreen) {
-        ShowkaseCurrentScreen.SHOWKASE_CATEGORIES -> {
-            ShowkaseCategoriesScreen(showkaseBrowserScreenMetadata)
+    NavHost(
+        navController = navController,
+        startDestination = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name
+    ) {
+        composable(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES.name) {
+            ShowkaseCategoriesScreen(
+                showkaseBrowserScreenMetadata, 
+                navController
+            )
         }
-        ShowkaseCurrentScreen.COMPONENT_GROUPS -> {
+        composable(ShowkaseCurrentScreen.COMPONENT_GROUPS.name) {
             ShowkaseComponentGroupsScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP.name) {
             ShowkaseComponentsInAGroupScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata, 
+                navController
             )
         }
-        ShowkaseCurrentScreen.COMPONENT_DETAIL -> {
+        composable(ShowkaseCurrentScreen.COMPONENT_DETAIL.name) {
             ShowkaseComponentDetailScreen(
                 groupedComponentMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COLOR_GROUPS -> {
+        composable(ShowkaseCurrentScreen.COLOR_GROUPS.name) {
             ShowkaseColorGroupsScreen(
                 groupedColorsMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.COLORS_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.COLORS_IN_A_GROUP.name) {
             ShowkaseColorsInAGroupScreen(
                 groupedColorsMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS -> {
+        composable(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS.name) {
             ShowkaseTypographyGroupsScreen(
                 groupedTypographyMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
-        ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP -> {
+        composable(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP.name) {
             ShowkaseTypographyInAGroupScreen(
                 groupedTypographyMap,
-                showkaseBrowserScreenMetadata
+                showkaseBrowserScreenMetadata,
+                navController
             )
         }
     }
 }
+
+/**
+ * Helper function to navigate to the passed [ShowkaseCurrentScreen]
+ */
+internal fun NavHostController.navigate(destinationScreen: ShowkaseCurrentScreen) = 
+    navigate(destinationScreen.name)

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,5 +1,7 @@
 package com.airbnb.android.showkase.ui
 
+import android.graphics.Color
+import android.graphics.drawable.Icon
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -37,6 +39,8 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
 import com.airbnb.android.showkase.models.insideGroup
+import org.w3c.dom.Text
+import java.time.format.TextStyle
 
 @Composable
 internal fun ShowkaseBrowserApp(
@@ -164,6 +168,7 @@ private fun ShowkaseAppBarActions(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
 internal fun ShowkaseBodyContent(
     navController: NavHostController,

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,6 +1,5 @@
 package com.airbnb.android.showkase.ui
 
-import android.graphics.Color
 import android.graphics.drawable.Icon
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.background
@@ -39,8 +38,6 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
 import com.airbnb.android.showkase.models.insideGroup
-import org.w3c.dom.Text
-import java.time.format.TextStyle
 
 @Composable
 internal fun ShowkaseBrowserApp(

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseCategoriesScreen.kt
@@ -1,23 +1,26 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.compose.ui.platform.ContextAmbient
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCategory
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 import java.util.Locale
 
 @Composable
 internal fun ShowkaseCategoriesScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
-    val activity = (LifecycleOwnerAmbient.current as ComponentActivity)
-    
+    val activity = ContextAmbient.current as  AppCompatActivity
     LazyColumnFor(items = ShowkaseCategory.values().toList()) { category ->
         val defaultlLocale = Locale.getDefault()
         SimpleTextCard(
@@ -25,14 +28,20 @@ internal fun ShowkaseCategoriesScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = when(category) {
-                            ShowkaseCategory.COMPONENTS -> ShowkaseCurrentScreen.COMPONENT_GROUPS
-                            ShowkaseCategory.COLORS -> ShowkaseCurrentScreen.COLOR_GROUPS
-                            ShowkaseCategory.TYPOGRAPHY -> ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS
-                        },
                         currentGroup = null,
                         isSearchActive = false,
                         searchQuery = null
+                    )
+                }
+                when(category) {
+                    ShowkaseCategory.COMPONENTS -> navController.navigate(
+                        ShowkaseCurrentScreen.COMPONENT_GROUPS
+                    )
+                    ShowkaseCategory.COLORS -> navController.navigate(
+                        ShowkaseCurrentScreen.COLOR_GROUPS
+                    )
+                    ShowkaseCategory.TYPOGRAPHY -> navController.navigate(
+                        ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS
                     )
                 }
             }
@@ -44,7 +53,7 @@ internal fun ShowkaseCategoriesScreen(
 }
 
 private fun goBackFromCategoriesScreen(
-    activity: ComponentActivity,
+    activity: AppCompatActivity,
     showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
@@ -55,19 +64,17 @@ private fun goBackFromCategoriesScreen(
 }
 
 internal fun goBackToCategoriesScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
-    val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
+    
     when {
-        isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.SHOWKASE_CATEGORIES,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null,
-                currentGroup = null
-            )
+        showkaseBrowserScreenMetadata.value.isSearchActive -> {
+            showkaseBrowserScreenMetadata.clearActiveSearch()
+        }
+        else ->  {
+            showkaseBrowserScreenMetadata.clear()
+            navController.navigate(ShowkaseCurrentScreen.SHOWKASE_CATEGORIES)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorGroupsScreen.kt
@@ -3,6 +3,8 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -11,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseColorGroupsScreen(
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedColorsMap.keys.sorted(),
@@ -23,16 +26,16 @@ internal fun ShowkaseColorGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.COLORS_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     ) 
                 }
+                navController.navigate(ShowkaseCurrentScreen.COLORS_IN_A_GROUP)
             }
         )
     })
     BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -20,16 +20,20 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserColor
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 
 @Composable
 internal fun ShowkaseColorsInAGroupScreen(
     groupedColorsMap: Map<String, List<ShowkaseBrowserColor>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupColorsList =
         groupedColorsMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -70,24 +74,20 @@ internal fun ShowkaseColorsInAGroupScreen(
         }
     )
     BackButtonHandler {
-        goBackFromColorsInAGroupScreen(showkaseBrowserScreenMetadata)
+        goBackFromColorsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun  goBackFromColorsInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.COLOR_GROUPS,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null,
-                currentGroup = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.clear()
+            navController.navigate(ShowkaseCurrentScreen.COLOR_GROUPS)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.R
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
@@ -53,7 +55,8 @@ import java.util.Locale
 @Composable
 internal fun ShowkaseComponentDetailScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val componentMetadataList =
         groupedComponentMap[showkaseBrowserScreenMetadata.value.currentGroup] ?: return
@@ -80,7 +83,7 @@ internal fun ShowkaseComponentDetailScreen(
         }
     })
     BackButtonHandler {
-        back(showkaseBrowserScreenMetadata)
+        back(showkaseBrowserScreenMetadata, navController)
     }
     
 }
@@ -202,13 +205,16 @@ internal fun generateComposableModifier(metadata: ShowkaseBrowserComponent): Mod
     }
 }
 
-private fun back(showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>) {
+private fun back(
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
+) {
     showkaseBrowserScreenMetadata.update {
         copy(
-            currentScreen = ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP,
             currentComponent = null,
             isSearchActive = false,
             searchQuery = null
         )
     }
+    navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP)
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentGroupsScreen.kt
@@ -1,10 +1,10 @@
 package com.airbnb.android.showkase.ui
 
-import androidx.activity.ComponentActivity
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.ui.platform.LifecycleOwnerAmbient
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -13,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseComponentGroupsScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedComponentMap.keys.sorted(),
@@ -26,17 +27,17 @@ internal fun ShowkaseComponentGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     )
                 }
+                navController.navigate(ShowkaseCurrentScreen.COMPONENTS_IN_A_GROUP)
             }
         )
     })
     BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentsInAGroupScreen.kt
@@ -3,16 +3,20 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 
 @Composable
 internal fun ShowkaseComponentsInAGroupScreen(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupComponentsList =
         groupedComponentMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -28,34 +32,30 @@ internal fun ShowkaseComponentsInAGroupScreen(
                 onClick = {
                     showkaseBrowserScreenMetadata.update {
                         copy(
-                            currentScreen = ShowkaseCurrentScreen.COMPONENT_DETAIL,
                             currentComponent = groupComponent.componentName,
                             isSearchActive = false
                         )
                     }
+                    navController.navigate(ShowkaseCurrentScreen.COMPONENT_DETAIL)
                 }
             )
         }
     )
     BackButtonHandler {
-        goBackFromComponentsInAGroupScreen(showkaseBrowserScreenMetadata)
+        goBackFromComponentsInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun goBackFromComponentsInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.COMPONENT_GROUPS,
-                currentGroup = null,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.clear()
+            navController.navigate(ShowkaseCurrentScreen.COMPONENT_GROUPS)
         }
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyGroupsScreen.kt
@@ -3,6 +3,8 @@ package com.airbnb.android.showkase.ui
 import androidx.compose.foundation.lazy.LazyColumnFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
@@ -11,7 +13,8 @@ import com.airbnb.android.showkase.models.update
 @Composable
 internal fun ShowkaseTypographyGroupsScreen(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val filteredList = getFilteredSearchList(
         groupedTypographyMap.keys.sorted(),
@@ -24,16 +27,16 @@ internal fun ShowkaseTypographyGroupsScreen(
             onClick = {
                 showkaseBrowserScreenMetadata.update {
                     copy(
-                        currentScreen = ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP,
                         currentGroup = group,
                         isSearchActive = false,
                         searchQuery = null
                     )
                 }
+                navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_IN_A_GROUP)
             }
         )
     })
     BackButtonHandler {
-        goBackToCategoriesScreen(showkaseBrowserScreenMetadata)
+        goBackToCategoriesScreen(showkaseBrowserScreenMetadata, navController)
     }
 }

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseTypographyInAGroupScreen.kt
@@ -11,12 +11,12 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.scrollBy
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.navigate
+import androidx.navigation.NavHostController
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseBrowserTypography
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
+import com.airbnb.android.showkase.models.clear
 import com.airbnb.android.showkase.models.clearActiveSearch
 import com.airbnb.android.showkase.models.update
 import java.util.Locale
@@ -24,7 +24,8 @@ import java.util.Locale
 @Composable
 internal fun ShowkaseTypographyInAGroupScreen(
     groupedTypographyMap: Map<String, List<ShowkaseBrowserTypography>>,
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val groupTypographyList =
         groupedTypographyMap[showkaseBrowserScreenMetadata.value.currentGroup]
@@ -46,24 +47,20 @@ internal fun ShowkaseTypographyInAGroupScreen(
         }
     )
     BackButtonHandler {
-        goBackFromTypographyInAGroupScreen(showkaseBrowserScreenMetadata)
+        goBackFromTypographyInAGroupScreen(showkaseBrowserScreenMetadata, navController)
     }
 }
 
 private fun goBackFromTypographyInAGroupScreen(
-    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>
+    showkaseBrowserScreenMetadata: MutableState<ShowkaseBrowserScreenMetadata>,
+    navController: NavHostController
 ) {
     val isSearchActive = showkaseBrowserScreenMetadata.value.isSearchActive
     when {
         isSearchActive -> showkaseBrowserScreenMetadata.clearActiveSearch()
-        else -> showkaseBrowserScreenMetadata.update {
-            copy(
-                currentScreen = ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS,
-                currentGroup = null,
-                currentComponent = null,
-                isSearchActive = false,
-                searchQuery = null
-            )
+        else -> {
+            showkaseBrowserScreenMetadata.clear()
+            navController.navigate(ShowkaseCurrentScreen.TYPOGRAPHY_GROUPS)
         }
     }
 }


### PR DESCRIPTION
I ended up merging my previous PR(https://github.com/airbnb/Showkase/pull/119) into the wrong base branch so this never ended up making it to master. This PR merely cherry picks that commit

Compose alpha06 comes with Jetpack Navigation support. In this PR, I make use of that for doing navigation in the Showkase Browser App

@airbnb/showkase-maintainers