### PR TITLE
Changing rt lib for java 11 and adding java 11 to github CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,6 +36,11 @@ jobs:
         api-level: [21, 23, 29]
         target: [default, google_apis]
     steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Checkout Branch
         uses: actions/checkout@v2
       - uses: actions/cache@v1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [21, 23, 29]
+        api-level: [26, 28, 29]
         target: [default, google_apis]
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
             'composeNavigation': '1.0.0-alpha06',
             'detekt': '1.7.4',
             'espresso': '3.2.0',
-            'gradle': '4.2.0-alpha15',
+            'gradle': '7.0.0-alpha08',
             'junit' : '4.12',
             'junitImplementation' : '1.1.1',
             'kotlin': '1.4.21-2',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.2-bin.zip

--- a/sample-submodule/build.gradle
+++ b/sample-submodule/build.gradle
@@ -9,11 +9,11 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/sample-submodule/build.gradle
+++ b/sample-submodule/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,12 +9,12 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.airbnb.android.showkasesample"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId "com.airbnb.android.showkasesample"
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.internal.jvm.Jvm
-
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
@@ -78,20 +76,6 @@ dependencies {
     androidTestImplementation deps.test.androidxTestRunner
     // Allows this module to access the annotation processor related classes. Otherwise those are
     // only available in java library modules.
-    testImplementation files(getRuntimeJar())
+    testImplementation files('libs/rt.jar')
     testImplementation deps.kotlinCompileTesting
-}
-
-static def getRuntimeJar() {
-    try {
-        final File javaBase = new File(System.getProperty("java.home")).getCanonicalFile()
-        File runtimeJar = new File(javaBase, "jmods/java.base.jmod")
-        if (runtimeJar.exists()) {
-            return runtimeJar
-        }
-        runtimeJar = new File(javaBase, "jre/jmods/java.base.jmod")
-        return runtimeJar.exists() ? runtimeJar : null
-    } catch (IOException e) {
-        throw new RuntimeException(e)
-    }
 }

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -14,7 +14,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -76,22 +76,20 @@ dependencies {
     androidTestImplementation deps.test.androidXTestCore
     androidTestImplementation deps.test.androidXTestRules
     androidTestImplementation deps.test.androidxTestRunner
-    // Allows this module to access the annotation processor related classes. Otherwise those are 
-    // only available in java library modules. Inspiration - 
-    // https://github.com/airbnb/epoxy/blob/master/epoxy-processortest/build.gradle
+    // Allows this module to access the annotation processor related classes. Otherwise those are
+    // only available in java library modules.
     testImplementation files(getRuntimeJar())
-    testImplementation files(Jvm.current().getToolsJar())
     testImplementation deps.kotlinCompileTesting
 }
 
 static def getRuntimeJar() {
     try {
         final File javaBase = new File(System.getProperty("java.home")).getCanonicalFile()
-        File runtimeJar = new File(javaBase, "lib/rt.jar")
+        File runtimeJar = new File(javaBase, "jmods/java.base.jmod")
         if (runtimeJar.exists()) {
             return runtimeJar
         }
-        runtimeJar = new File(javaBase, "jre/lib/rt.jar")
+        runtimeJar = new File(javaBase, "jre/jmods/java.base.jmod")
         return runtimeJar.exists() ? runtimeJar : null
     } catch (IOException e) {
         throw new RuntimeException(e)

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -13,7 +13,7 @@ android {
         exclude("META-INF/*.kotlin_module")
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -21,11 +21,11 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -24,7 +24,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
@vinaygaba 

- Seems like tools.jar is actually no longer needed with > Java 9.

### Issues with rt.jar
- The class and resource files previously stored in lib/rt.jar, lib/tools.jar, lib/dt.jar, and various other internal jar files will now be stored in a more efficient format in implementation-specific files in the lib directory. [StackOverflow](https://stackoverflow.com/questions/53707666/how-to-get-tools-jar-for-openjdk-11-on-windows)
- I greped and I found that abstractProcessor is in jmods/java.compiler.jmod
- However the JDK which comes with Android Studio doesn't have jmods, but Oracle JDK contains it.
- If you just copy this folder to android studio jdk path, it'll start working locally by adding `File runtimePath = new File(javaBase, "jmods/java.compiler.jmod")` to build.gradle
- I tried adding this jmod file in libs folder in the project, but it doesn't work the same way as rt.jar in libs folder.
 1. We can ask the users to move jmods folder to the android studio jdk directory and then use , however that obv is unreasonable.
 2. Ask users to download oracle jdk and then change the JAVA_HOME to that jdk and then we can use jmods
3. **Only working option as of now is to package the rt.jar in the libs folder.**

### About size
- It adds 64 MB, but I'll install git-lfs in the next PR which will reduce the size to clone and then pull the large file rt.jar later
`


