### PR TITLE
Upgraded Showkase to Java11

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches
@@ -38,6 +38,10 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,12 +36,13 @@ jobs:
         api-level: [21, 23, 29]
         target: [default, google_apis]
     steps:
-      - name: Checkout Branch
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Checkout Branch
+        uses: actions/checkout@v2
       - uses: actions/cache@v1
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        api-level: [21, 23, 29]
+        api-level: [26, 28, 29]
         target: [default, google_apis]
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             'composeNavigation': '1.0.0-alpha09',
             'detekt': '1.7.4',
             'espresso': '3.2.0',
-            'gradle': '4.2.0-alpha15',
+            'gradle': '7.0.0-alpha12',
             'junit' : '4.12',
             'junitImplementation' : '1.1.1',
             'kotlin': '1.4.31',

--- a/sample-submodule/build.gradle
+++ b/sample-submodule/build.gradle
@@ -9,7 +9,7 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
@@ -27,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,12 +9,12 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.airbnb.android.showkasesample"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -29,11 +29,11 @@ android {
     }
     
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true

--- a/showkase-annotation/build.gradle
+++ b/showkase-annotation/build.gradle
@@ -15,13 +15,13 @@ plugins {
 apply plugin: "com.vanniktech.maven.publish"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -1,11 +1,9 @@
-import org.gradle.internal.jvm.Jvm
-
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -16,7 +14,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures
@@ -24,11 +22,11 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true
@@ -80,21 +78,6 @@ dependencies {
     // Allows this module to access the annotation processor related classes. Otherwise those are 
     // only available in java library modules. Inspiration - 
     // https://github.com/airbnb/epoxy/blob/master/epoxy-processortest/build.gradle
-    testImplementation files(getRuntimeJar())
-    testImplementation files(Jvm.current().getToolsJar())
+    testImplementation files('libs/rt.jar')
     testImplementation deps.kotlinCompileTesting
-}
-
-static def getRuntimeJar() {
-    try {
-        final File javaBase = new File(System.getProperty("java.home")).getCanonicalFile()
-        File runtimeJar = new File(javaBase, "lib/rt.jar")
-        if (runtimeJar.exists()) {
-            return runtimeJar
-        }
-        runtimeJar = new File(javaBase, "jre/lib/rt.jar")
-        return runtimeJar.exists() ? runtimeJar : null
-    } catch (IOException e) {
-        throw new RuntimeException(e)
-    }
 }

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -13,7 +13,7 @@ android {
         exclude("META-INF/*.kotlin_module")
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its

--- a/showkase-processor/build.gradle
+++ b/showkase-processor/build.gradle
@@ -29,13 +29,13 @@ sourceSets {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileKotlin {
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -21,7 +21,7 @@ kapt {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
@@ -40,11 +40,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true


### PR DESCRIPTION
Took another stab at upgrading Showkase to Java 11. Doing this required making changes to the dependency on `rt.jar` as that jar file is not available on in Java 11 anymore. Took the` rt.jar` file from the embedded Java files that comes with Android Studio and added it to the project.  Since its only for the testing module, this should be fine to do (although I do wish there was a better solution as this isn't my first preference). 

This PR is almost identical to where @meggamind landed in his PR as well - https://github.com/airbnb/Showkase/pull/132 with the exception that I'm only bumping up the `minSdkVersion` in the testing module and not the main module. This was a pretty important requirement for me personally as Showkase should be available to as many projects as possible so I didn't want to bump up the `minSdkVersion` for the entire project. I'm happy to either merge this PR or clean up the existing one and merge that PR!