### PR TITLE
Get rid of unnecessary `Class.forName` call

### DIFF
--- a/showkase-processor/build.gradle
+++ b/showkase-processor/build.gradle
@@ -20,14 +20,6 @@ kapt {
     generateStubs = true
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir "${buildDir.absolutePath}/tmp/kapt/main/kotlinGenerated/"
-        }
-    }
-}
-
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -55,10 +55,10 @@ class ShowkaseProcessor: AbstractProcessor() {
         filter = processingEnv.filer
         messager = processingEnv.messager
         composableTypeMirror = elementUtils
-            .getTypeElement(Class.forName(COMPOSABLE_CLASS_NAME).canonicalName)
+            .getTypeElement(COMPOSABLE_CLASS_NAME)
             .asType()
         textStyleTypeMirror = elementUtils
-            .getTypeElement(Class.forName(TYPE_STYLE_CLASS_NAME).canonicalName)
+            .getTypeElement(TYPE_STYLE_CLASS_NAME)
             .asType()
     }
 


### PR DESCRIPTION
Get rid of unnecessary `Class.forName` call from a couple places

Fixes #157 

@BenSchwab @elihart 