### PR TITLE
Make Showkase compatible with not including kapt on compile classpath

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
+kapt.include.compile.classpath=false
         
 VERSION_NAME=1.0.0-beta02
 GROUP=com.airbnb.android

--- a/showkase-processor/build.gradle
+++ b/showkase-processor/build.gradle
@@ -34,7 +34,7 @@ compileKotlin {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    compileOnly project(':showkase-annotation')
+    implementation project(':showkase-annotation')
 
     implementation deps.autoService
     implementation deps.kotlinStdLib


### PR DESCRIPTION
Was seeing a crash due to Showkase annotations classes being not found when this property was set to false

```gradle
kapt.include.compile.classpath=false
```

This was happening as I had a `compileOnly` dependency on `showkase:annotations`. Made this to implementation dependency like the other libraries (Epoxy, Paris, etc)

@BenSchwab @elihart 