### PR TITLE
Remove `Context`-manipulating code from `RTLComponentCard`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ buildscript {
             'supportLibrary': '1.1.0',
             'testRunner': '1.2.0',
             'googleTruth': '1.0.1',
-            'autoService': '1.0-rc7'
+            'autoService': '1.0-rc7',
+            'material':'1.4.0',
+            'mdcComposeThemeAdapter':'1.0.2'
     ]
     ext.deps = [
             'autoService': "com.google.auto.service:auto-service:${versions.autoService}",
@@ -63,6 +65,10 @@ buildscript {
                     'junit': "junit:junit:${versions.junit}",
                     'junitImplementation': "androidx.test.ext:junit:${versions.junitImplementation}",
                     'androidxTestRunner': "androidx.test:runner:${versions.testRunner}"
+            ],
+            'material': [
+                    'material':"com.google.android.material:material:${versions.material}",
+                    'mdcComposeThemeAdapter':"com.google.android.material:compose-theme-adapter:${versions.mdcComposeThemeAdapter}"
             ]
     ]
     repositories {

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     androidTestImplementation deps.compose.uiTest
 
     // Material
+    implementation deps.material.material
     implementation deps.material.mdcComposeThemeAdapter
 
     // Testing

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     implementation deps.compose.tooling
     androidTestImplementation deps.compose.uiTest
 
+    // Material
+    implementation deps.material.mdcComposeThemeAdapter
+
     // Testing
     testImplementation deps.test.assertJ
     testImplementation deps.test.googleTruth

--- a/showkase-processor-testing/src/main/java/com/airbnb/android/showkase_processor_testing/TestComposables.kt
+++ b/showkase-processor-testing/src/main/java/com/airbnb/android/showkase_processor_testing/TestComposables.kt
@@ -7,11 +7,14 @@ import androidx.compose.ui.platform.LocalContext
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
+import com.google.android.material.composethemeadapter.MdcTheme
 
 @ShowkaseComposable("Composable1", "Group1")
 @Composable
 fun TestComposable1() {
-    BasicText(text = "Test Composable1")
+    MdcTheme {
+        BasicText(text = "Test Composable1")
+    }
 }
 
 @ShowkaseComposable("Composable2", "Group1")

--- a/showkase-processor-testing/src/main/res/values/styles.xml
+++ b/showkase-processor-testing/src/main/res/values/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.App.NoActionBar" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+</resources>

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation deps.compose.layout
     implementation deps.compose.material
     androidTestImplementation deps.compose.uiTest
+
+    // Material
+    implementation deps.material.material
     
     // Unit Testing
     testImplementation deps.test.junit

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -87,9 +87,6 @@ dependencies {
     implementation deps.compose.material
     androidTestImplementation deps.compose.uiTest
 
-    // Material
-    implementation deps.material.material
-    
     // Unit Testing
     testImplementation deps.test.junit
     androidTestImplementation deps.test.junitImplementation

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -52,7 +52,6 @@ import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.airbnb.android.showkase.models.ShowkaseBrowserScreenMetadata
 import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
 import com.airbnb.android.showkase.models.update
-import java.util.Locale
 
 @Composable
 internal fun ShowkaseComponentDetailScreen(

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseComponentDetailScreen.kt
@@ -169,20 +169,12 @@ private fun DisplayScaledComponentCard(metadata: ShowkaseBrowserComponent) {
 
 @Composable
 private fun RTLComponentCard(metadata: ShowkaseBrowserComponent) {
-    val customConfiguration = Configuration(LocalConfiguration.current).apply {
-        val locale = Locale("ar")
-        setLocale(locale)
-        setLayoutDirection(locale)
-    }
-    val customContext = LocalContext.current.createConfigurationContext(customConfiguration)
     ComponentCardTitle("${metadata.componentName} [RTL]")
-    CompositionLocalProvider(LocalContext provides customContext) {
-        val updatedModifier = Modifier.generateComposableModifier(metadata)
-        Card(modifier = Modifier.fillMaxWidth()) {
-            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
-                Column(modifier = updatedModifier) {
-                    metadata.component()
-                }
+    val updatedModifier = Modifier.generateComposableModifier(metadata)
+    Card(modifier = Modifier.fillMaxWidth()) {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+            Column(modifier = updatedModifier) {
+                metadata.component()
             }
         }
     }

--- a/showkase/src/main/res/values/styles.xml
+++ b/showkase/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.App" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
     </style>
 

--- a/showkase/src/main/res/values/styles.xml
+++ b/showkase/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.App" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
     </style>
 


### PR DESCRIPTION
Given `LocalLayoutDirection`, it is no longer necessary.

This should fix Issue #167.
