### PR TITLE
Added weight attr to Text in ShowkaseColorsInAGroupScreen

### DIFF
--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseColorsInAGroupScreen.kt
@@ -60,7 +60,7 @@ internal fun ShowkaseColorsInAGroupScreen(
                     ) {
                         Text(
                             text = groupColorMetadata.colorName,
-                            modifier = Modifier.padding(start = padding4x, end = padding4x),
+                            modifier = Modifier.padding(start = padding4x, end = padding4x).weight(1f),
                             style = TextStyle(
                                 fontSize = 20.sp,
                                 fontFamily = FontFamily.Serif,


### PR DESCRIPTION
If the name was long(eg. DarkOnSecondaryContainer) in the ShowkaseColor list, the color was not shown.
I added weight attr to text sovled

before Pixel XL          |  After Pixel XL
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/6470409/150703839-fa9fb29d-22bb-4a4f-86ab-8bd5f77b6540.png" width="40%"/>  |  <img src="https://user-images.githubusercontent.com/6470409/150703846-de124f71-8d5c-46d2-9c37-44372a17c80c.png" width="40%"/>


before Nexus 10          |  After Nexus 10
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/6470409/150703845-e4551ea9-e25f-4c2b-afac-4d3fcbe28b28.png" width="40%"/>  |  <img src="https://user-images.githubusercontent.com/6470409/150703946-5e253573-d3cc-499d-a3aa-a5d44300f125.png" width="40%"/>