### PR TITLE
Fix super small previews when @Preview annotation doesn't specify width and height

### DIFF
--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [Composables::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun WrapperClass_TestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun WrapperClass_TestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun WrapperClass_TestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group1_name1(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group1_name1(): Unit {
   }
@@ -32,9 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group1_name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,8 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1,
     previewParameterClass = [ParameterProvider::class]
   )
   public fun group_name(): Unit {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
@@ -28,8 +28,6 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                       componentKey =
                           """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null_$index""",
                       isDefaultStyle = false,
-                      widthDp = -1,
-                      heightDp = -1,
                       component = @Composable { WrapperClass.TestComposable(previewParam) }
                   )
               )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -24,8 +24,6 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentKDoc = "",
             componentKey = """com.airbnb.android.showkase_processor_testing_null_group_name_null""",
             isDefaultStyle = false,
-            widthDp = -1,
-            heightDp = -1,
             component = @Composable { TestComposable() })
       )
 

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,8 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1,
     previewParameterClass = [ParameterProvider::class]
   )
   public fun group_name(): Unit {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,9 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun Default_Group_TestComposable(): Unit {
   }
@@ -34,8 +32,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1,
     previewParameterClass = [ParameterProvider::class]
   )
   public fun Default_Group_TestComposable2(): Unit {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -25,8 +25,6 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentKey =
                 """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
             isDefaultStyle = false,
-            widthDp = -1,
-            heightDp = -1,
             component = @Composable { TestComposable() })
       ).apply {
           ParameterProvider().values.iterator().asSequence().forEachIndexed { index, previewParam ->
@@ -39,8 +37,6 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                       componentKey =
                           """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_null_$index""",
                       isDefaultStyle = false,
-                      widthDp = -1,
-                      heightDp = -1,
                       component = @Composable { TestComposable2(previewParam) }
                   )
               )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun Default_Group_TestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -25,8 +25,6 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentKey =
                 """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
             isDefaultStyle = false,
-            widthDp = -1,
-            heightDp = -1,
             component = @Composable { TestComposable() })
       )
 

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,9 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun Default_Group_TestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,9 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-    showkaseWidthDp = -1,
-    showkaseHeightDp = -1
+    isDefaultStyle = false
   )
   public fun group_name(): Unit {
   }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -263,6 +263,9 @@ internal fun getShowkaseMetadataFromPreview(
         commonMetadata.enclosingClass,
     )
 
+    val width = previewAnnotation.getAsInt("widthDp")
+    val height = previewAnnotation.getAsInt("heightDp")
+
     return ShowkaseMetadata.Component(
         packageSimpleName = commonMetadata.moduleName,
         packageName = commonMetadata.packageName,
@@ -271,8 +274,8 @@ internal fun getShowkaseMetadataFromPreview(
         showkaseKDoc = commonMetadata.kDoc,
         showkaseName = showkaseName,
         showkaseGroup = showkaseGroup,
-        showkaseWidthDp = previewAnnotation.getAsInt("widthDp"),
-        showkaseHeightDp = previewAnnotation.getAsInt("heightDp"),
+        showkaseWidthDp = if (width == -1) null else width,
+        showkaseHeightDp = if (height == -1) null else width,
         insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
         insideObject = commonMetadata.showkaseFunctionType.insideObject(),
         element = element,


### PR DESCRIPTION
Seems like this logic changed after the ksp upgrade. This PR fixes it and also updates tests

https://github.com/airbnb/Showkase/issues/204

@airbnb/showkase-maintainers 