### PR TITLE
Fix illegal chars getting generated into function names.

### DIFF
--- a/sample/src/main/java/com/airbnb/android/showkasesample/Text.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/Text.kt
@@ -143,3 +143,14 @@ fun H6TextRowComponentPreview(
 ) {
     H6TextRowComponent(person.name)
 }
+
+// This is here for testing, generating this code into function names would
+// fail dex generation
+@Preview(name = "H6 Text Row & special chars !@#$%^&*()_+", group = "Text")
+@Composable
+fun H6TextRowComponentPreviewWithSpecialCharInPreview(
+    age: String = "15",
+    @PreviewParameter(provider = ParameterProvider::class) person: Person
+) {
+    H6TextRowComponent(person.name)
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name1(): Unit {
+  public fun group1name1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -32,7 +32,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group2_name2(): Unit {
+  public fun group2name2(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -46,7 +46,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun color_name(): Unit {
+  public fun colorname(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -60,6 +60,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun typography_name(): Unit {
+  public fun typographyname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,7 +20,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable1(): Unit {
+  public fun WrapperClassTestComposable1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -37,6 +37,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun Default_Group_TestComposable2(): Unit {
+  public fun DefaultGroupTestComposable2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun WrapperClass_name(): Unit {
+  public fun WrapperClassname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [ShowkaseObject::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [Composables::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,6 +20,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [NewParameterProvider::class],
     previewParameterName = "bankHeader"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group2_name2(): Unit {
+  public fun group2name2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,6 +20,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun WrapperClass_TestComposable(): Unit {
+  public fun WrapperClassTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name1(): Unit {
+  public fun group1name1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -32,6 +32,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name2(): Unit {
+  public fun group1name2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name1(): Unit {
+  public fun group1name1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -32,6 +32,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name2(): Unit {
+  public fun group1name2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name1(): Unit {
+  public fun group1name1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -32,6 +32,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name2(): Unit {
+  public fun group1name2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -22,6 +22,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun WrapperClass_Red(): Unit {
+  public fun WrapperClassRed(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun WrapperClass_Title(): Unit {
+  public fun WrapperClassTitle(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun WrapperClass_Red(): Unit {
+  public fun WrapperClassRed(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun WrapperClass_Title(): Unit {
+  public fun WrapperClassTitle(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [ShowkaseObject::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,6 +18,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [Composables::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun component_name(): Unit {
+  public fun componentname(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -31,6 +31,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun color_name(): Unit {
+  public fun colorname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group1_name1(): Unit {
+  public fun group1name1(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -32,6 +32,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group2_name2(): Unit {
+  public fun group2name2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,6 +20,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,6 +20,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun component_name(): Unit {
+  public fun componentname(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -33,6 +33,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COLOR"
   )
-  public fun color_name(): Unit {
+  public fun colorname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun component_name(): Unit {
+  public fun componentname(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -33,6 +33,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun typography_name(): Unit {
+  public fun typographyname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -35,6 +35,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun Default_Group_TestComposable2(): Unit {
+  public fun DefaultGroupTestComposable2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_TestComposable(): Unit {
+  public fun groupTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,6 +17,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun Default_Group_TestComposable(): Unit {
+  public fun DefaultGroupTestComposable(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -35,6 +35,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun Default_Group_TestComposable2(): Unit {
+  public fun DefaultGroupTestComposable2(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "COLOR"
   )
-  public fun Default_Group_Red(): Unit {
+  public fun DefaultGroupRed(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun Default_Group_Title(): Unit {
+  public fun DefaultGroupTitle(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun component_name(): Unit {
+  public fun componentname(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
@@ -31,6 +31,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun typography_name(): Unit {
+  public fun typographyname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,6 +16,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     showkaseMetadataType = "TYPOGRAPHY"
   )
-  public fun group_Title(): Unit {
+  public fun groupTitle(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,6 +19,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -22,6 +22,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -22,6 +22,6 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     previewParameterClass = [ParameterProvider::class],
     previewParameterName = "text"
   )
-  public fun group_name(): Unit {
+  public fun groupname(): Unit {
   }
 }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
@@ -38,7 +38,7 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
                 "${name}_${showkaseMetadata.showkaseStyleName}"
             } else {
                 name
-            }.replace(" ", "_")
+            }.filter { it.isLetterOrDigit() }
 
             val annotation = createShowkaseCodegenMetadata(showkaseMetadata)
             showkaseMetadata.enclosingClassName?.let {


### PR DESCRIPTION
Illegal chars might get generated into function names which compile in Kotlin but are not allowed in dex and will lead to build errors.