### PR TITLE
Specify the type names of the generated ShowkaseProvider functions (explicit-api support)

### DIFF
--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
@@ -41,6 +41,7 @@ abstract class BaseProcessorTest {
 
         modes.forEach { mode ->
             val compilation = KotlinCompilation().apply {
+                kotlincArguments = kotlincArguments + "-Xexplicit-api=strict"
                 sources = inputDir.listFiles()?.toList().orEmpty().map { SourceFile.fromPath(it) }
                 when (mode) {
                     Mode.KSP -> {
@@ -91,7 +92,7 @@ abstract class BaseProcessorTest {
         }
         outputDir.mkdirs()
 
-        val generatedSources = when (mode){
+        val generatedSources = when (mode) {
             Mode.KSP -> compilation.kspSourcesDir.walk().filter { it.isFile }.toList()
             Mode.KAPT -> sourcesGeneratedByAnnotationProcessor
         }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/basic_function_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/basic_function_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,8 +1,8 @@
 import androidx.compose.ui.tooling.preview.Preview
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @Preview("name", "group")
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/basic_function_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/basic_function_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,8 +1,8 @@
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseComposable("name", "group")
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_ShowkaseTypography_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_ShowkaseTypography_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -2,5 +2,5 @@
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography("name", "group")
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -2,8 +2,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
 @Preview("name", "group")
-class GeneratedTestComposables {
-    fun TestComposable() {
+public class GeneratedTestComposables {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -2,8 +2,8 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "group")
-class GeneratedTestComposables {
-    fun TestComposable() {
+public class GeneratedTestComposables {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/MyShowkaseScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/MyShowkaseScreenshotTest.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotType
 
 @ShowkaseScreenshot(rootShowkaseClass = TestShowkaseRoot::class)
-abstract class MyScreenshotTest: ShowkaseScreenshotTest {
+public abstract class MyScreenshotTest: ShowkaseScreenshotTest {
     override fun onScreenshot(
         id: String,
         name: String,

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/input/testComposables.kt
@@ -10,20 +10,20 @@ import androidx.compose.ui.text.font.FontFamily
 
 @ShowkaseComposable(name = "name1", group = "group1")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }
 
 @ShowkaseComposable(name = "name2", group = "group2")
 @Composable
-fun TestComposable2() {
+public fun TestComposable2() {
     
 }
 
 @ShowkaseColor("name", "color")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)
 
 @ShowkaseTypography("name", "typography")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
@@ -52,9 +52,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/MyShowkaseScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/MyShowkaseScreenshotTest.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotType
 
 @ShowkaseScreenshot(rootShowkaseClass = TestShowkaseRoot::class)
-abstract class MyScreenshotTest: ShowkaseScreenshotTest {
+public abstract class MyScreenshotTest: ShowkaseScreenshotTest {
     override fun onScreenshot(
         id: String,
         name: String,

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/input/testComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.runtime.Composable
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",
@@ -16,10 +16,10 @@ class ParameterProvider : PreviewParameterProvider<String> {
         get() = super.count
 }
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseComposable
     @Composable
-    fun TestComposable1() {
+    public fun TestComposable1() {
         
     }
 }
@@ -27,6 +27,6 @@ class WrapperClass {
 
 @ShowkaseComposable
 @Composable
-fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+public fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
@@ -47,9 +47,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_no_interface_but_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_no_interface_but_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -5,11 +5,11 @@ import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseComposable("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
 @ShowkaseRoot
-class TestClass() {
+public class TestClass() {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/closed_class_with_right_interface_and_showkasescreenshottest_annotation_throws_compilation_error/input/MyScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/closed_class_with_right_interface_and_showkasescreenshottest_annotation_throws_compilation_error/input/MyScreenshotTest.kt
@@ -3,4 +3,4 @@ import com.airbnb.android.showkase.annotation.ShowkaseScreenshot
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 
 @ShowkaseScreenshot(rootShowkaseClass = String::class)
-class MyScreenshotTest: ShowkaseScreenshotTest
+public class MyScreenshotTest: ShowkaseScreenshotTest

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseColor("name", "group")
-    val color = Color(0xffff0000)
+    public val color: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/input/GeneratedTestComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseColor("name")
-    val color = Color(0xffff0000)
+    public val color: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -3,7 +3,7 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-object ShowkaseObject {
+public object ShowkaseObject {
     @ShowkaseColor("name", "group")
-    val color = Color(0xffff0000)
+    public val color: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseColor("name", "group")
-    val color = Color(0xffff0000)
+    public val color: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/input/Composables.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 
-class Composables {
+public class Composables {
     @ShowkaseColor("name", "group")
-    val red = Color(0xffff0000)
+    public val red: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class ShowkaseClass {
-    companion object {
+public class ShowkaseClass {
+    public companion object {
         @Preview("name", "group")
         @Composable
-        fun TestComposable() {
+        public fun TestComposable() {
             
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
-    companion object {
+public class WrapperClass {
+    public companion object {
         @Preview("name", "group")
         @Composable
-        fun TestComposable() {
+        public fun TestComposable() {
         
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
-    companion object {
+public class WrapperClass {
+    public companion object {
         @ShowkaseComposable("name", "group")
         @Composable
-        fun TestComposable() {
+        public fun TestComposable() {
             
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class ShowkaseClass {
-    companion object {
+public class ShowkaseClass {
+    public companion object {
         @ShowkaseComposable("name", "group")
         @Composable
-        fun TestComposable() {
+        public fun TestComposable() {
             
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
-class WrapperClass {
-    companion object {
+public class WrapperClass {
+    public companion object {
         @ShowkaseComposable("name", "group")
         @Composable
-        fun TestComposable() {
+        public fun TestComposable() {
         
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-object ShowkaseObject {
+public object ShowkaseObject {
     @Preview("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-object WrapperObject {
+public object WrapperObject {
     @Preview("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
     
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-object ShowkaseObject {
+public object ShowkaseObject {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
-object WrapperObject {
+public object WrapperObject {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
     
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/input/TestComposable.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/input/TestComposable.kt
@@ -7,14 +7,14 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @ShowkaseComposable(name = "name", group = "group")
 @Composable
-fun TestComposableWithDefaultParameters(
+public fun TestComposableWithDefaultParameters(
     age: Int = 5,
     @PreviewParameter(provider = NewParameterProvider::class) bankHeader: BankHeader
 ) {
 
 }
 
-class NewParameterProvider : PreviewParameterProvider<BankHeader> {
+public class NewParameterProvider : PreviewParameterProvider<BankHeader> {
     override val values: Sequence<BankHeader>
         get() = sequenceOf(
             BankHeader("Citi", 12),
@@ -26,7 +26,7 @@ class NewParameterProvider : PreviewParameterProvider<BankHeader> {
 
 }
 
-data class BankHeader(
-    val name: String,
-    val age: Int,
+public data class BankHeader(
+    public val name: String,
+    public val age: Int,
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
@@ -39,9 +39,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_non_preview_parameters_and_preview_annotation_throws_Exception/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_non_preview_parameters_and_preview_annotation_throws_Exception/input/GeneratedTestComposables.kt
@@ -1,10 +1,10 @@
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @Preview("name", "group")
     @Composable
-    fun TestComposable(name: String, age: Int) {
+    public fun TestComposable(name: String, age: Int) {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_parameters_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_parameters_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,10 +1,10 @@
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable(name: String, age: Int) {
+    public fun TestComposable(name: String, age: Int) {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/input/testComposables.kt
@@ -7,6 +7,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 @Preview("name1", "group1")
 @ShowkaseComposable("name2", "group2")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/input/GeneratedTestComposables.kt
@@ -3,7 +3,7 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-object WrapperClass {
+public object WrapperClass {
     /**
      * This component shows some static text in cursive text style.
      *
@@ -16,7 +16,7 @@ object WrapperClass {
      */
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
@@ -41,9 +41,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_partial_default_parameters_throws_compilation_error/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_partial_default_parameters_throws_compilation_error/input/Composables.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @Preview("name", "group")
 @Composable
-fun TestComposable(
+public fun TestComposable(
     name: String = "",
     age: Int
 ) {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_preview_annotation_inside_class_with_parameters_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_preview_annotation_inside_class_with_parameters_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,10 +1,10 @@
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
-class GeneratedTestComposables(name: String) {
+public class GeneratedTestComposables(name: String) {
     @Composable
     @Preview("name", "group")
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_showkase_annotation_inside_class_with_parameters_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_showkase_annotation_inside_class_with_parameters_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,10 +1,10 @@
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class GeneratedTestComposables(name: String) {
+public class GeneratedTestComposables(name: String) {
     @Composable
     @ShowkaseComposable("name", "group")
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/input/Composables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class Composables {
+public class Composables {
     @Preview("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/input/Composables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class Composables {
+public class Composables {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
+public class WrapperClass {
     @Preview
     @Composable
-    fun testComposable() {
+    public fun testComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseComposable
     @Composable
-    fun testComposable() {
+    public fun testComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
-    companion object {
+public class WrapperClass {
+    public companion object {
         @Preview
         @Composable
-        fun testComposable() {
+        public fun testComposable() {
             
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,11 +3,11 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
-    companion object {
+public class WrapperClass {
+    public companion object {
         @ShowkaseComposable
         @Composable
-        fun testComposable() {
+        public fun testComposable() {
             
         }
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-object WrapperClass {
+public object WrapperClass {
     @Preview
     @Composable
-    fun testComposable() {
+    public fun testComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseComposable
     @Composable
-    fun testComposable() {
+    public fun testComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/method_with_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/method_with_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -3,15 +3,15 @@ import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }
 
 @ShowkaseRoot
-fun testMethod() {
+public fun testMethod() {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_classes_with_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_classes_with_showkaseroot_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -3,16 +3,16 @@ import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
         
     }
 }
 
 @ShowkaseRoot
-class RootModule1: ShowkaseRootModule
+public class RootModule1: ShowkaseRootModule
 
 @ShowkaseRoot
-class RootModule2: ShowkaseRootModule
+public class RootModule2: ShowkaseRootModule

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/input/testComposables.kt
@@ -6,12 +6,12 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @Preview("name1", "group1")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }
 
 @ShowkaseComposable("name2", "group1")
 @Composable
-fun TestComposable2() {
+public fun TestComposable2() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/input/testComposables.kt
@@ -5,12 +5,12 @@ import androidx.compose.runtime.Composable
 
 @Preview("name1", "group1")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }
 
 @Preview("name2", "group1")
 @Composable
-fun TestComposable2() {
+public fun TestComposable2() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/input/testComposables.kt
@@ -5,12 +5,12 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name1", "group1")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }
 
 @ShowkaseComposable("name2", "group1")
 @Composable
-fun TestComposable2() {
+public fun TestComposable2() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/non-long_value_annotated_with_ShowkaseColor_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/non-long_value_annotated_with_ShowkaseColor_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,6 +1,6 @@
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseColor("name", "group")
-    val red = "Hello"
+    public val red = "Hello"
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/non-text_style_value_annotated_with_ShowkaseTypography_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/non-text_style_value_annotated_with_ShowkaseTypography_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,7 +1,7 @@
     
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseTypography("name", "group")
-    val red = "Hello"
+    public val red = "Hello"
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_annotated_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -2,8 +2,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
 @Preview("name", "group")
-object GeneratedTestComposables {
-    fun TestComposable() {
+public object GeneratedTestComposables {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_annotated_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -2,8 +2,8 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "group")
-object GeneratedTestComposables {
-    fun TestComposable() {
+public object GeneratedTestComposables {
+    public fun TestComposable() {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/input/GeneratedTestComposables.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.runtime.Composable
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",
@@ -17,10 +17,10 @@ class ParameterProvider : PreviewParameterProvider<String> {
         get() = super.count
 }
 
-object WrapperClass {
+public object WrapperClass {
     @Preview(name = "name", group = "group")
     @Composable
-    fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+    public fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
@@ -38,9 +38,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/private_composable_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/private_composable_with_preview_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,7 +1,7 @@
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @Preview("name", "group")
     @Composable
     private fun TestComposable() {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/private_composable_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/private_composable_with_showkase_annotation_throws_compilation_error/input/GeneratedTestComposables.kt
@@ -1,7 +1,7 @@
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import androidx.compose.runtime.Composable
 
-class GeneratedTestComposables {
+public class GeneratedTestComposables {
     @ShowkaseComposable("name", "group")
     @Composable
     private fun TestComposable() {

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,7 +3,7 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseColor
-    val red = Color(0xffff0000)
+    public val red: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseTypography
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -3,7 +3,7 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseColor
-    val red = Color(0xffff0000)
+    public val red: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/input/GeneratedTestComposables.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseTypography
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseTypography("name", "group")
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = WrapperClass().title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/input/GeneratedTestComposables.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-object ShowkaseObject {
+public object ShowkaseObject {
     @ShowkaseTypography("name", "group")
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/GeneratedTestComposables.kt
@@ -6,9 +6,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-object WrapperClass {
+public object WrapperClass {
     @ShowkaseTypography("name", "group")
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = WrapperClass.title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/input/Composables.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
-class Composables {
+public class Composables {
     @ShowkaseTypography("name", "group")
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/GeneratedTestColors.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/GeneratedTestColors.kt
@@ -3,6 +3,5 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
-
 @ShowkaseColor("name", "group")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotType
 
 @ShowkaseScreenshot(rootShowkaseClass = TestShowkaseRoot::class)
-abstract class MyScreenshotTest: ShowkaseScreenshotTest {
+public abstract class MyScreenshotTest: ShowkaseScreenshotTest {
     override fun onScreenshot(
         id: String,
         name: String,

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/input/testComposables.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "component")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
 @ShowkaseColor("name", "color")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -38,9 +38,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/input/testComposables.kt
@@ -4,4 +4,4 @@ import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 @ShowkaseColor("name", "group")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -4,4 +4,4 @@ import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 @ShowkaseColor("name", "group")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/input/testComposables.kt
@@ -4,4 +4,4 @@ import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 @ShowkaseColor("name", "group")
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotType
 
 @ShowkaseScreenshot(rootShowkaseClass = TestShowkaseRoot::class)
-abstract class MyScreenshotTest: ShowkaseScreenshotTest {
+public abstract class MyScreenshotTest: ShowkaseScreenshotTest {
     override fun onScreenshot(
         id: String,
         name: String,

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/testComposables.kt
@@ -5,12 +5,12 @@ import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
 @ShowkaseComposable(name= "name1", group = "group1")
 @Composable
-fun TestComposable1() {
+public fun TestComposable1() {
     
 }
 
 @ShowkaseComposable(name= "name2", group = "group2")
 @Composable
-fun TestComposable2() {
+public fun TestComposable2() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -40,9 +40,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @Preview("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -31,9 +31,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @Preview("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @Preview("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 
 @Preview(name = "name", group = "group")
 @Composable
-fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+public fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
 }
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -7,11 +7,11 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable(name = "name", group = "group")
 @Composable
-fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+public fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
 }
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -31,9 +31,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "group")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -7,11 +7,11 @@ import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 @ShowkaseComposable("name", "component")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseColor("name", "color")
-    val red = Color(0xffff0000)
+    public val red: Color = Color(0xffff0000)
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -8,13 +8,13 @@ import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseComposable("name", "component")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseTypography("name", "typography")
-    val title = TextStyle(
+    public val title: TextStyle = TextStyle(
         fontFamily = FontFamily.Cursive
     )
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
@@ -7,17 +7,17 @@ import androidx.compose.runtime.Composable
 
 @Preview
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
 @Preview
 @Composable
-fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+public fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
 }
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -47,9 +47,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @Preview
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @Preview
 @Composable
-fun testComposable() {
+public fun testComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable(group = "group")
 @Composable
-fun testComposable() {
+public fun testComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -32,9 +32,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable
 @Composable
-fun testComposable() {
+public fun testComposable() {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/input/testComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.runtime.Composable
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",
@@ -18,12 +18,12 @@ class ParameterProvider : PreviewParameterProvider<String> {
 
 @ShowkaseComposable
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
 @ShowkaseComposable
 @Composable
-fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+public fun TestComposable2(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -47,9 +47,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/input/testComposables.kt
@@ -4,4 +4,4 @@ import androidx.compose.ui.graphics.Color
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 
 @ShowkaseColor
-val red = Color(0xffff0000)
+public val red: Color = Color(0xffff0000)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/GeneratedTestColors.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/GeneratedTestColors.kt
@@ -5,6 +5,6 @@ import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography("name", "group")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/MyShowkaseScreenshotTest.kt
@@ -6,7 +6,7 @@ import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotTest
 import com.airbnb.android.showkase.screenshot.testing.ShowkaseScreenshotType
 
 @ShowkaseScreenshot(rootShowkaseClass = TestShowkaseRoot::class)
-abstract class MyScreenshotTest: ShowkaseScreenshotTest {
+public abstract class MyScreenshotTest: ShowkaseScreenshotTest {
     override fun onScreenshot(
         id: String,
         name: String,

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/input/testComposables.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 
 @ShowkaseComposable("name", "component")
 @Composable
-fun TestComposable() {
+public fun TestComposable() {
     
 }
 
 @ShowkaseTypography("name", "typography")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -38,9 +38,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography("name", "group")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography("name", "group")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/input/testComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/input/testComposables.kt
@@ -5,6 +5,6 @@ import androidx.compose.ui.text.font.FontFamily
 import com.airbnb.android.showkase.annotation.ShowkaseTypography
 
 @ShowkaseTypography(group = "group")
-val title = TextStyle(
+public val title: TextStyle = TextStyle(
     fontFamily = FontFamily.Cursive
 )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootCodegen.kt
@@ -28,9 +28,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             textStyle = title)
       )
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -3,10 +3,10 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
 
-class WrapperClass {
+public class WrapperClass {
     @Preview("name", "group")
     @Composable
-    fun TestComposable() {
+    public fun TestComposable() {
     
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/input/GeneratedTestComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",
@@ -16,10 +16,10 @@ class ParameterProvider : PreviewParameterProvider<String> {
         get() = super.count
 }
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseComposable("name", "group")
     @Composable
-    fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+    public fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
     
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/input/GeneratedTestComposables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/input/GeneratedTestComposables.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.runtime.Composable
 
-class ParameterProvider : PreviewParameterProvider<String> {
+public class ParameterProvider : PreviewParameterProvider<String> {
     override val values: Sequence<String>
         get() = sequenceOf(
             "String1",
@@ -16,10 +16,10 @@ class ParameterProvider : PreviewParameterProvider<String> {
         get() = super.count
 }
 
-class WrapperClass {
+public class WrapperClass {
     @ShowkaseComposable(name = "name", group = "group")
     @Composable
-    fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
+    public fun TestComposable(@PreviewParameter(provider = ParameterProvider::class) text: String) {
         
     }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/input/TestShowkaseRoot.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/input/TestShowkaseRoot.kt
@@ -6,6 +6,6 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 
 @ShowkaseRoot
-class TestShowkaseRoot: ShowkaseRootModule {
+public class TestShowkaseRoot: ShowkaseRootModule {
 
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
@@ -38,9 +38,9 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
 
   public val typographyList: List<ShowkaseBrowserTypography> = listOf<ShowkaseBrowserTypography>()
 
-  public override fun getShowkaseComponents() = componentList
+  public override fun getShowkaseComponents(): List<ShowkaseBrowserComponent> = componentList
 
-  public override fun getShowkaseColors() = colorList
+  public override fun getShowkaseColors(): List<ShowkaseBrowserColor> = colorList
 
-  public override fun getShowkaseTypography() = typographyList
+  public override fun getShowkaseTypography(): List<ShowkaseBrowserTypography> = typographyList
 }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
@@ -7,7 +7,9 @@ import com.airbnb.android.showkase.processor.models.ShowkaseMetadata
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.LIST
 import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeName
 
@@ -52,16 +54,19 @@ internal class ShowkaseBrowserWriter(private val environment: XProcessingEnv) {
             typographyProperty.build(),
             showkaseComponentMetadata + showkaseColorMetadata + showkaseTypographyMetadata,
             getShowkaseProviderInterfaceFunction(
-                COMPONENT_INTERFACE_METHOD_NAME,
-                COMPONENT_PROPERTY_NAME
+                methodName = COMPONENT_INTERFACE_METHOD_NAME,
+                returnPropertyName = COMPONENT_PROPERTY_NAME,
+                returnType = LIST.parameterizedBy(SHOWKASE_BROWSER_COMPONENT_CLASS_NAME)
             ),
             getShowkaseProviderInterfaceFunction(
-                COLOR_INTERFACE_METHOD_NAME,
-                COLOR_PROPERTY_NAME
+                methodName = COLOR_INTERFACE_METHOD_NAME,
+                returnPropertyName = COLOR_PROPERTY_NAME,
+                returnType = LIST.parameterizedBy(SHOWKASE_BROWSER_COLOR_CLASS_NAME)
             ),
             getShowkaseProviderInterfaceFunction(
-                TYPOGRAPHY_INTERFACE_METHOD_NAME,
-                TYPOGRAPHY_PROPERTY_NAME
+                methodName = TYPOGRAPHY_INTERFACE_METHOD_NAME,
+                returnPropertyName = TYPOGRAPHY_PROPERTY_NAME,
+                returnType = LIST.parameterizedBy(SHOWKASE_BROWSER_TYPOGRAPHY_CLASS_NAME)
             ),
             showkaseRootCodegenAnnotation
         )
@@ -111,7 +116,7 @@ internal class ShowkaseBrowserWriter(private val environment: XProcessingEnv) {
                 closeCurlyBraces()
             }
         }
-        
+
         componentListProperty.initializer(componentListInitializerCodeBlock.build())
         return componentListProperty
     }
@@ -252,8 +257,10 @@ internal class ShowkaseBrowserWriter(private val environment: XProcessingEnv) {
                 .add("\n$fieldPropertyName = %T.${fieldName}", enclosingClass)
                 .build()
         }
-        else -> throw ShowkaseProcessorException("Your field:${fieldName} is declared in a way that " +
-                "is not supported by Showkase")
+        else -> throw ShowkaseProcessorException(
+            "Your field:${fieldName} is declared in a way that " +
+                    "is not supported by Showkase"
+        )
     }
 
     companion object {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -32,16 +32,18 @@ internal fun getFileBuilder(
 
 internal fun getPropertyList(className: ClassName, propertyName: String): PropertySpec.Builder {
     val parameterizedList = className.getCodegenMetadataParameterizedList()
-    
+
     return PropertySpec.builder(propertyName, parameterizedList)
 }
 
 internal fun getShowkaseProviderInterfaceFunction(
     methodName: String,
-    returnPropertyName: String
+    returnPropertyName: String,
+    returnType: TypeName,
 ) = FunSpec.builder(methodName)
     .addModifiers(KModifier.OVERRIDE)
     .addStatement("return $returnPropertyName")
+    .returns(returnType)
     .build()
 
 @Suppress("LongParameterList")


### PR DESCRIPTION
In order to support kotlins explicit api, the return types must be specified. Additionally enables explicit-api in the processor tests to catch future regressions.