### PR TITLE
Add close and clear button for search field

### DIFF
--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -476,4 +476,72 @@ class ShowcaseBrowserTest {
             verifyLineCountIsValue(3)
         }
     }
+
+    @Test
+    fun search_field_has_enabled_close_button() {
+        composeTestRule.apply {
+            // Assert that all the categories are displayed on the screen and that they are clickable.
+            verifyLandingScreen()
+
+            // Tap on the "Components" row
+            clickRowWithText("Components (7)")
+
+            // Tap on the search icon
+            clickRowWithTag("SearchIcon")
+
+            waitForIdle()
+
+            // Check that the search close button is displayed and clickable
+            verifyButtonWithTagIsDisplayedAndEnabled("close_search_bar_tag")
+
+            // Click the close button
+            clickRowWithTag("close_search_bar_tag")
+
+            waitForIdle()
+
+            // Check that the search icon is displayed again
+            verifyButtonWithTagIsDisplayedAndEnabled("SearchIcon")
+        }
+    }
+
+    @Test
+    fun clear_search_field_clears_the_field() {
+        composeTestRule.apply {
+            // Assert that all the categories are displayed on the screen and that they are clickable.
+            verifyLandingScreen()
+
+            // Tap on the "Components" row
+            clickRowWithText("Components (7)")
+
+            waitForIdle()
+
+            // Tap on the search icon
+            clickRowWithTag("SearchIcon")
+
+            waitForIdle()
+
+            // Check that the search close button is displayed and clickable
+            verifyButtonWithTagIsDisplayedAndEnabled("close_search_bar_tag")
+
+            // Enter "Bod" in the search field
+            inputTextWithTag("SearchTextField", "Bod")
+
+            // Check that the clear search field button is enabled when there is input text
+            verifyButtonWithTagIsDisplayedAndEnabled("clear_search_field")
+
+            // Click to clear the text
+            clickRowWithTag("clear_search_field")
+
+            // Check that only the label is displayed
+            verifyRowsWithTextAreDisplayed("Search")
+
+            waitForIdle()
+
+            // Click the close button
+            clickRowWithTag("close_search_bar_tag")
+
+            // Check that the search icon is displayed again
+            verifyButtonWithTagIsDisplayedAndEnabled("SearchIcon")
+        }
+    }
 }

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTestFlows.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTestFlows.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onChildren
@@ -106,5 +107,14 @@ internal fun AndroidComposeTestRule<ActivityScenarioRule<ShowkaseBrowserActivity
     value: Int
 ) {
     onNode(SemanticsMatcher.expectValue(LineCountKey, value)).assertExists()
+}
+
+internal fun AndroidComposeTestRule<ActivityScenarioRule<ShowkaseBrowserActivity>, ShowkaseBrowserActivity>.verifyButtonWithTagIsDisplayedAndEnabled(
+    tag: String
+) {
+    onNodeWithTag(tag)
+        .assertExists("Node with tag: $tag does not exist")
+        .assertIsDisplayed()
+        .assertIsEnabled()
 }
 


### PR DESCRIPTION
Thanks for a supercool library! I really like it! 😍 😄 

When using the library, I found that there where no button for closing and clearing the search field. I added one and wrapped it in the `AnimatedVisibility` composable for a nice transition effect. Feel free to close this if you don't like it :) 

Also added a test for verifying that the close button works as intended in `:showkase-browser-testing`

[search_bar_clear.webm](https://user-images.githubusercontent.com/54936943/179353874-9ca66d24-43d3-4b05-a4b6-30625cd26e99.webm)

What do you think about this @vinaygaba ? 😄 
