### PR TITLE
Bump Compose version to latest stable 1.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,25 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.KSP_VERSION = '1.6.10-1.0.4'
+    ext.KSP_VERSION = '1.7.0-1.0.6'
 
     ext.versions = [
             'androidXTestCore':'1.4.0',
             'androidXTestRules':'1.4.0',
             'assertJ': '3.16.1',
-            'compose': '1.1.1',
-            'composeActivity': '1.4.0',
-            'composeConstraintLayout': '1.0.0',
-            'composeNavigation': '2.4.1',
+            'compose': '1.2.0',
+            'composeActivity': '1.5.0',
+            'composeConstraintLayout': '1.0.1',
+            'composeNavigation': '2.5.1',
             'detekt': '1.7.4',
             'espresso': '3.2.0',
-            'gradle': '7.0.3',
+            'gradle': '7.2.1',
             'junit' : '4.13',
             'junitImplementation' : '1.1.2',
-            'kotlin': '1.6.10',
-            'kotlinCompilerVersion': '1.6.10',
-            'kotlinCompileTesting': '1.4.7',
-            'kotlinPoet': '1.10.2',
-            'kotlinXMetadata': '0.4.0',
+            'kotlin': '1.7.0',
+            'kotlinCompilerVersion': '1.7.0',
+            'kotlinCompileTesting': '1.4.9',
+            'kotlinPoet': '1.12.0',
+            'kotlinXMetadata': '0.5.0',
             'ksp': "$KSP_VERSION",
             'ktx': '1.1.0',
             'lifecycle':'2.2.0',
@@ -30,7 +30,7 @@ buildscript {
             'material':'1.4.0',
             'mdcComposeThemeAdapter':'1.0.2',
             'strikt':'0.33.0',
-            'xprocessing':'2.4.2',
+            'xprocessing':'2.4.3',
             'corektx':'1.7.0',
             'shot': '5.13.0'
     ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip

--- a/sample-submodule/build.gradle
+++ b/sample-submodule/build.gradle
@@ -13,11 +13,11 @@ if (project.hasProperty('useKsp')) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,12 +14,12 @@ if (project.hasProperty('useKsp')) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         applicationId "com.airbnb.android.showkasesample"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         <activity
             android:name="com.airbnb.android.showkasesample.MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/Theme.App.NoActionBar">
+            android:theme="@style/Theme.App.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/showkase-annotation/build.gradle
+++ b/showkase-annotation/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     // Maven artifact publish
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
     }
 }
 

--- a/showkase-browser-testing-submodule/build.gradle
+++ b/showkase-browser-testing-submodule/build.gradle
@@ -11,7 +11,7 @@ if (project.hasProperty('useKsp')) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -22,7 +22,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 30
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase-browser-testing/build.gradle
+++ b/showkase-browser-testing/build.gradle
@@ -11,7 +11,7 @@ if (project.hasProperty('useKsp')) {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -22,7 +22,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 30
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -19,7 +19,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 30
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name1(): Unit {
   }
@@ -30,7 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group2name2(): Unit {
   }
@@ -44,7 +44,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun colorname(): Unit {
   }
@@ -58,7 +58,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun typographyname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 2,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable1(): Unit {
   }
@@ -35,7 +35,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun DefaultGroupTestComposable2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun WrapperClassname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [ShowkaseObject::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_with_showkase_color_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [Composables::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [ShowkaseObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperObject::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [NewParameterProvider::class],
-    previewParameterName = "bankHeader"
+    previewParameterName = "bankHeader",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group2name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
         "This component shows some static text in cursive text style.\n\n Example usage:\n\n ```\n @Composable\n fun MyComposable() { CursiveTextComponentPreview() }\n ```",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_preview_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [Composables::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_with_showkase_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [Composables::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_class_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_companion_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/function_inside_object_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun WrapperClassTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_and_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name1(): Unit {
   }
@@ -30,7 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_preview_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name1(): Unit {
   }
@@ -30,7 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/multiple_composable_functions_with_showkase_annotations_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name1(): Unit {
   }
@@ -30,7 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,7 +20,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing_my_very_long_name.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing_my_very_long_name.kt
@@ -21,7 +21,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing_my_v
     isDefaultStyle = false,
     previewParameterClass =
         [MyVeryLongPackageNameViewStateSomethingSomethingFunnyStuffProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun WrapperClassRed(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_class_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun WrapperClassTitle(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun WrapperClassRed(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/property_inside_object_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun WrapperClassTitle(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_ShowkaseTypography_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [ShowkaseObject::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_with_ShowkaseTypography_annotation_inside_class_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [Composables::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun componentname(): Unit {
   }
@@ -29,7 +29,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun colorname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 1,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group1name1(): Unit {
   }
@@ -30,7 +30,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun group2name2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 2,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_parameter_and_showkase_composable_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -18,7 +18,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_compiles_ok/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_color_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun componentname(): Unit {
   }
@@ -31,7 +31,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun colorname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_with_wrapped_textstyle_property_with_ShowkaseColor_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun componentname(): Unit {
   }
@@ -31,7 +31,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = true,
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun typographyname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }
@@ -33,7 +33,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun DefaultGroupTestComposable2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -16,7 +16,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun DefaultGroupTestComposable(): Unit {
   }
@@ -33,7 +33,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun DefaultGroupTestComposable2(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_color_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "COLOR"
+    showkaseMetadataType = "COLOR",
   )
   public fun DefaultGroupRed(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_property_with_showkase_typography_annotation_and_no_name_or_group/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun DefaultGroupTitle(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -15,7 +15,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideWrapperClass = false,
     showkaseKDoc = "",
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun componentname(): Unit {
   }
@@ -29,7 +29,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun typographyname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 1,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_ShowkaseTypography_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -14,7 +14,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseMetadataType = "TYPOGRAPHY"
+    showkaseMetadataType = "TYPOGRAPHY",
   )
   public fun groupTitle(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootCodegen.kt
@@ -12,7 +12,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 0,
   numColors = 0,
-  numTypography = 1
+  numTypography = 1,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_preview_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -17,7 +17,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseKDoc = "",
     enclosingClass = [WrapperClass::class],
     showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false
+    isDefaultStyle = false,
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_composable_function_with_showkase_annotation_generates_only_metadata_file/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,7 +20,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -20,7 +20,7 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
     previewParameterClass = [ParameterProvider::class],
-    previewParameterName = "text"
+    previewParameterName = "text",
   )
   public fun groupname(): Unit {
   }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
@@ -13,7 +13,7 @@ import kotlin.collections.List
   numComposablesWithoutPreviewParameter = 0,
   numComposablesWithPreviewParameter = 1,
   numColors = 0,
-  numTypography = 0
+  numTypography = 0,
 )
 public class TestShowkaseRootCodegen : ShowkaseProvider {
   public val componentList: List<ShowkaseBrowserComponent> =

--- a/showkase-processor/build.gradle
+++ b/showkase-processor/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     // Maven artifact publish
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
     }
 }
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
@@ -26,7 +26,7 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
             CODEGEN_PACKAGE_NAME,
             generatedClassName
         )
-            .addComment("This is an auto-generated file. Please do not edit/modify this file.")
+            .addFileComment("This is an auto-generated file. Please do not edit/modify this file.")
 
         val autogenClass = TypeSpec.classBuilder(generatedClassName)
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -28,7 +28,7 @@ internal fun getFileBuilder(
     rootModulePackageName,
     showkaseComponentsListClassName
 )
-    .addComment("This is an auto-generated file. Please do not edit/modify this file.")
+    .addFileComment("This is an auto-generated file. Please do not edit/modify this file.")
 
 internal fun getPropertyList(className: ClassName, propertyName: String): PropertySpec.Builder {
     val parameterizedList = className.getCodegenMetadataParameterizedList()

--- a/showkase-screenshot-testing-shot/build.gradle
+++ b/showkase-screenshot-testing-shot/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     // Maven artifact publish
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
     }
 }
 
@@ -16,7 +16,7 @@ plugins {
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -28,7 +28,7 @@ android {
     defaultConfig {
         testApplicationId "com.airbnb.android.showkase.screenshot.testing.shot"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         testInstrumentationRunner "com.karumi.shot.ShotTestRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase-screenshot-testing/build.gradle
+++ b/showkase-screenshot-testing/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     // Maven artifact publish
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
     }
 }
 
@@ -13,7 +13,7 @@ apply plugin: 'kotlin-android'
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
     // Added to avoid this error -
     // Execution failed for task ':showkase-processor-testing:mergeDebugAndroidTestJavaResource'.
     // > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
@@ -24,7 +24,7 @@ android {
     }
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     // Maven artifact publish
     dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
     }
 }
 
@@ -15,11 +15,11 @@ plugins {
 apply plugin: "com.vanniktech.maven.publish"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/showkase/src/main/AndroidManifest.xml
+++ b/showkase/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
             android:name="com.airbnb.android.showkase.ui.ShowkaseBrowserActivity"
             android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:label="ShowkaseBrowserActivity"
-            android:theme="@style/Theme.App.NoActionBar">
+            android:theme="@style/Theme.App.NoActionBar"
+            android:exported="true">
         </activity>
     </application>
 </manifest>

--- a/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
+++ b/showkase/src/main/java/com/airbnb/android/showkase/ui/ShowkaseBrowserApp.kt
@@ -1,5 +1,6 @@
 package com.airbnb.android.showkase.ui
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandHorizontally
@@ -57,6 +58,7 @@ import com.airbnb.android.showkase.models.ShowkaseCurrentScreen
 import com.airbnb.android.showkase.models.insideGroup
 import com.airbnb.android.showkase.ui.SemanticsUtils.lineCountVal
 
+@SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 internal fun ShowkaseBrowserApp(
     groupedComponentMap: Map<String, List<ShowkaseBrowserComponent>>,


### PR DESCRIPTION
Thanks for a supercool library! 😄 🤩 

### Overview

In this PR I have updated Showkase to target the latest stable version of Jetpack Compose. That required us to bump the following as well: 

 * AGP 7.2.1
 * Kotlin 1.7.0
 * KotlinCompilerTesting 1.4.9
 * KotlinPoet 1.12.0
 * KotlinXMetadata 0.5.0
 * XProcessing 2.4.3

We also had to target SDK version 32.

There where some small breaking changes from bumping these libraries that I have fixed as well 😄 

This fixes #248 😄 