### PR TITLE
Bump compose compiler to 1.3.1 and libs to 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.KSP_VERSION = '1.7.0-1.0.6'
+    ext.KSP_VERSION = '1.7.10-1.0.6'
 
     ext.versions = [
             'androidXTestCore'       : '1.4.0',
             'androidXTestRules'      : '1.4.0',
             'assertJ'                : '3.16.1',
-            'compose'                : '1.2.0',
-            'composeActivity'        : '1.5.0',
+            'compose'                : '1.2.1',
+            'composeCompiler'        : '1.3.1',
+            'composeActivity'        : '1.5.1',
             'composeConstraintLayout': '1.0.1',
             'composeNavigation'      : '2.5.1',
             'detekt'                 : '1.7.4',
@@ -15,7 +16,7 @@ buildscript {
             'gradle'                 : '7.2.1',
             'junit'                  : '4.13',
             'junitImplementation'    : '1.1.2',
-            'kotlin'                 : '1.7.0',
+            'kotlin'                 : '1.7.10',
             'kotlinCompilerVersion'  : '1.7.0',
             'kotlinCompileTesting'   : '1.4.9',
             'kotlinPoet'             : '1.12.0',
@@ -37,7 +38,7 @@ buildscript {
     ext.deps = [
             'compose'                : [
                     'activityCompose'   : "androidx.activity:activity-compose:${versions.composeActivity}",
-                    'composeComplier'   : "androidx.compose:compose-compiler:${versions.compose}",
+                    'composeComplier'   : "androidx.compose:compose-compiler:${versions.composeCompiler}",
                     'composeNavigation' : "androidx.navigation:navigation-compose:${versions.composeNavigation}",
                     'composeRuntime'    : "androidx.compose.runtime:runtime:${versions.compose}",
                     'constraintLayout'  : "androidx.constraintlayout:constraintlayout-compose:${versions.composeConstraintLayout}",

--- a/sample-submodule/build.gradle
+++ b/sample-submodule/build.gradle
@@ -40,7 +40,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
 
     }
     // Added to avoid this error -

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -44,7 +44,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
 
     }
     // Added to avoid this error -

--- a/showkase-browser-testing-submodule/build.gradle
+++ b/showkase-browser-testing-submodule/build.gradle
@@ -41,7 +41,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     // Added to avoid this error -
     // Execution failed for task ':app:mergeDebugAndroidTestJavaResource'.

--- a/showkase-browser-testing/build.gradle
+++ b/showkase-browser-testing/build.gradle
@@ -48,7 +48,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     // Added to avoid this error -
     // Execution failed for task ':app:mergeDebugAndroidTestJavaResource'.

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     configurations {
         all {

--- a/showkase-screenshot-testing-shot/build.gradle
+++ b/showkase-screenshot-testing-shot/build.gradle
@@ -50,7 +50,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     // Added to avoid this error -
     // Execution failed for task ':app:mergeDebugAndroidTestJavaResource'.

--- a/showkase-screenshot-testing/build.gradle
+++ b/showkase-screenshot-testing/build.gradle
@@ -43,7 +43,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     // Added to avoid this error -
     // Execution failed for task ':app:mergeDebugAndroidTestJavaResource'.

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -46,7 +46,7 @@ android {
     }
     composeOptions {
         kotlinCompilerVersion "${versions.kotlinCompilerVersion}"
-        kotlinCompilerExtensionVersion "${versions.compose}"
+        kotlinCompilerExtensionVersion "${versions.composeCompiler}"
     }
     // Added to avoid this error -
     // Execution failed for task ':app:mergeDebugAndroidTestJavaResource'.


### PR DESCRIPTION
In this PR I have bumped the Compose compiler version to 1.3.0 and the libs to 1.2.1 as the latest stable version 😄

This also meant I had to bump the following:

- KSP -> 1.7.10-1.0.6
- Compose activity -> 1.5.1
- Kotlin -> 1.7.10
- KotlinCompilerVersion -> 1.7.10
