### PR TITLE
Fix wrong @ShowkaseRoot target

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Here's an example of how you would use it:
 
 ```kotlin
 @ShowkaseRoot
-fun MyRootModule: ShowkaseRootModule
+class MyRootModule: ShowkaseRootModule
 ```
 
 Note: The root module is the main module of your app that has a dependency on all other modules 


### PR DESCRIPTION
Fixed an issue where `@ShowkaseRoot` was applied to `fun` in the @ShowkaseRoot part of the Documentation section.