### PR TITLE
Make multi-preview annotations not throw at compiletime

### DIFF
--- a/sample/src/main/java/com/airbnb/android/showkasesample/CustomButton.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/CustomButton.kt
@@ -1,7 +1,5 @@
 package com.airbnb.android.showkasesample
 
-import android.content.res.Configuration.UI_MODE_NIGHT_NO
-import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
@@ -48,7 +45,7 @@ fun getPadding(
 fun PreviewCustomButtonDefault() {
     CustomButton(
         text = "Button",
-        onClick = {  }
+        onClick = { }
     )
 }
 
@@ -57,7 +54,7 @@ fun PreviewCustomButtonDefault() {
 fun PreviewCustomButtonMedium() {
     CustomButton(
         text = "Button",
-        onClick = {  },
+        onClick = { },
         size = ButtonSize.Medium
     )
 }
@@ -67,33 +64,10 @@ fun PreviewCustomButtonMedium() {
 fun PreviewCustomButtonSmall() {
     CustomButton(
         text = "Button",
-        onClick = {  },
+        onClick = { },
         size = ButtonSize.Small
     )
 }
-
-@Preview(
-    name = "Custom Button Light",
-    group = "Button",
-    uiMode = UI_MODE_NIGHT_NO,
-)
-@Preview(
-    name = "Custom Button Dark",
-    group = "Button",
-    uiMode = UI_MODE_NIGHT_YES,
-)
-annotation class CustomButtonPreview
-
-@CustomButtonPreview
-@Composable
-fun PreviewCustomButton() {
-    CustomButton(
-        text = "Button new Preview",
-        onClick = {  },
-        size = ButtonSize.Small
-    )
-}
-
 
 @Suppress("MatchingDeclarationName")
 enum class ButtonSize {

--- a/sample/src/main/java/com/airbnb/android/showkasesample/CustomButton.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/CustomButton.kt
@@ -1,5 +1,7 @@
 package com.airbnb.android.showkasesample
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -10,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
@@ -64,6 +67,28 @@ fun PreviewCustomButtonMedium() {
 fun PreviewCustomButtonSmall() {
     CustomButton(
         text = "Button",
+        onClick = {  },
+        size = ButtonSize.Small
+    )
+}
+
+@Preview(
+    name = "Custom Button Light",
+    group = "Button",
+    uiMode = UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Custom Button Dark",
+    group = "Button",
+    uiMode = UI_MODE_NIGHT_YES,
+)
+annotation class CustomButtonPreview
+
+@CustomButtonPreview
+@Composable
+fun PreviewCustomButton() {
+    CustomButton(
+        text = "Button new Preview",
         onClick = {  },
         size = ButtonSize.Small
     )

--- a/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
+++ b/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
@@ -1,8 +1,10 @@
 @file:Suppress("PackageNaming")
 package com.airbnb.android.showkase_browser_testing
 
+import android.content.res.Configuration
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
@@ -51,6 +53,25 @@ class WrapperComposableClass {
     }
 }
 
+// Adding this to see on the UI tests that this compiles.
+// Will remove it when we actually supports MultiPreviewAnnotations.
+@Preview(
+    name = "Custom Text Light",
+    group = "Button",
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+)
+@Preview(
+    name = "Custom Text Dark",
+    group = "Button",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+annotation class CustomButtonPreview
+
+@CustomButtonPreview
+@Composable
+fun PreviewCustomText() {
+    BasicText(text = "MultiPreviewAnnotation!")
+}
 
 @ShowkaseRoot
 class MyRootModule: ShowkaseRootModule

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
@@ -498,5 +498,10 @@ class ShowkaseProcessorTest : BaseProcessorTest() {
     fun `class with @ScreenshotTest generates screenshot test for all UI elements`() {
         compileInputsAndVerifyOutputs()
     }
+
+    @Test
+    fun `composable function with multiple preview functions compiles`() {
+        compileInputsAndVerifyOutputs()
+    }
 }
 

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
@@ -30,6 +30,7 @@ public annotation class DevicePreviews
 public class Composables {
 
     @FontScalePreviews
+    @Preview(name = "component", group = "component-group")
     @Composable
     public fun Component() {
     }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
@@ -1,0 +1,25 @@
+package com.airbnb.android.showkase_processor_testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+
+@Preview(
+    name = "small font",
+    group = "font scales",
+    fontScale = 0.5f
+)
+@Preview(
+    name = "large font",
+    group = "font scales",
+    fontScale = 1.5f
+)
+public annotation class FontScalePreviews
+
+public class Composables {
+
+    @FontScalePreviews
+    @Composable
+    public fun Component() {
+    }
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
@@ -3,7 +3,6 @@ package com.airbnb.android.showkase_processor_testing
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
-
 @Preview(
     name = "small font",
     group = "font scales",

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/input/Composables.kt
@@ -1,6 +1,8 @@
 package com.airbnb.android.showkase_processor_testing
 
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties.Text
 import androidx.compose.ui.tooling.preview.Preview
 
 @Preview(
@@ -15,10 +17,35 @@ import androidx.compose.ui.tooling.preview.Preview
 )
 public annotation class FontScalePreviews
 
+@Preview(
+    name = "small screen",
+    group = "device",
+)
+@Preview(
+    name = "large Screen",
+    group = "device",
+)
+public annotation class DevicePreviews
+
 public class Composables {
 
     @FontScalePreviews
     @Composable
     public fun Component() {
     }
+}
+
+@Preview(
+    name = "dark theme",
+    group = "themes",
+    uiMode = UI_MODE_NIGHT_YES
+)
+@FontScalePreviews
+@DevicePreviews
+public annotation class CombinedPreviews
+
+@CombinedPreviews
+@Composable
+public fun HelloWorldPreview() {
+
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_functions_compiles/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -1,0 +1,24 @@
+// This is an auto-generated file. Please do not edit/modify this file.
+package com.airbnb.android.showkase
+
+import com.airbnb.android.showkase.`annotation`.ShowkaseCodegenMetadata
+import com.airbnb.android.showkase_processor_testing.Composables
+import kotlin.Unit
+
+public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
+  @ShowkaseCodegenMetadata(
+    showkaseName = "component",
+    showkaseGroup = "component-group",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "Component",
+    insideObject = false,
+    insideWrapperClass = true,
+    showkaseKDoc = "",
+    enclosingClass = [Composables::class],
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+  )
+  public fun componentgroupcomponent(): Unit {
+  }
+}

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -103,13 +103,13 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     element,
                     PREVIEW_SIMPLE_NAME
                 )
-                if (element.isMethod()) {
+                if (showkaseValidator.checkElementIsMultiPreview(element)) {
+                    null
+                } else {
                     getShowkaseMetadataFromPreview(
                         element = element,
                         showkaseValidator = showkaseValidator
                     )
-                } else {
-                    null
                 }
             }.toSet()
     }
@@ -416,7 +416,6 @@ class ShowkaseProcessor @JvmOverloads constructor(
         const val COMPOSABLE_SIMPLE_NAME = "Composable"
         const val PREVIEW_CLASS_NAME = "androidx.compose.ui.tooling.preview.Preview"
         const val PREVIEW_SIMPLE_NAME = "Preview"
-        const val METADATA_SIMPLE_NAME = "Metadata"
         const val PREVIEW_PARAMETER_CLASS_NAME =
             "androidx.compose.ui.tooling.preview.PreviewParameter"
         const val PREVIEW_PARAMETER_SIMPLE_NAME = "PreviewParameter"

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -3,7 +3,6 @@ package com.airbnb.android.showkase.processor
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XRoundEnv
 import androidx.room.compiler.processing.XTypeElement
-import androidx.room.compiler.processing.isMethod
 import com.airbnb.android.showkase.annotation.ShowkaseCodegenMetadata
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -99,18 +98,17 @@ class ShowkaseProcessor @JvmOverloads constructor(
     private fun processPreviewAnnotation(roundEnvironment: XRoundEnv): Set<ShowkaseMetadata.Component> {
         return roundEnvironment.getElementsAnnotatedWith(PREVIEW_CLASS_NAME)
             .mapNotNull { element ->
+                if (showkaseValidator.checkElementIsMultiPreview(element)) return@mapNotNull null
                 showkaseValidator.validateComponentElement(
                     element,
                     PREVIEW_SIMPLE_NAME
                 )
-                if (showkaseValidator.checkElementIsMultiPreview(element)) {
-                    null
-                } else {
-                    getShowkaseMetadataFromPreview(
-                        element = element,
-                        showkaseValidator = showkaseValidator
-                    )
-                }
+
+                getShowkaseMetadataFromPreview(
+                    element = element,
+                    showkaseValidator = showkaseValidator
+                )
+
             }.toSet()
     }
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -416,6 +416,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
         const val COMPOSABLE_SIMPLE_NAME = "Composable"
         const val PREVIEW_CLASS_NAME = "androidx.compose.ui.tooling.preview.Preview"
         const val PREVIEW_SIMPLE_NAME = "Preview"
+        const val METADATA_SIMPLE_NAME = "Metadata"
         const val PREVIEW_PARAMETER_CLASS_NAME =
             "androidx.compose.ui.tooling.preview.PreviewParameter"
         const val PREVIEW_PARAMETER_SIMPLE_NAME = "PreviewParameter"

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -3,6 +3,7 @@ package com.airbnb.android.showkase.processor
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XRoundEnv
 import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.isMethod
 import com.airbnb.android.showkase.annotation.ShowkaseCodegenMetadata
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
@@ -102,10 +103,14 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     element,
                     PREVIEW_SIMPLE_NAME
                 )
-                getShowkaseMetadataFromPreview(
-                    element = element,
-                    showkaseValidator = showkaseValidator
-                )
+                if (element.isMethod()) {
+                    getShowkaseMetadataFromPreview(
+                        element = element,
+                        showkaseValidator = showkaseValidator
+                    )
+                } else {
+                    null
+                }
             }.toSet()
     }
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -39,20 +39,20 @@ internal class ShowkaseValidator {
         }
 
         when {
-            !element.isMethod() && !checkElementIsMultiPreview(element) -> {
+            !element.isMethod() -> {
                 throw ShowkaseProcessorException(
                     "Only composable methods can be annotated with $annotationName",
                     element
                 )
             }
             // Only check simple name to avoid costly type resolution
-            element.isMethod() && element.findAnnotationBySimpleName(COMPOSABLE_SIMPLE_NAME) == null -> {
+            element.findAnnotationBySimpleName(COMPOSABLE_SIMPLE_NAME) == null -> {
                 throw ShowkaseProcessorException(
                     "Only composable methods can be annotated with $annotationName",
                     element
                 )
             }
-            element.isMethod() && element.isPrivate() -> {
+            element.isPrivate() -> {
                 throw ShowkaseProcessorException(
                     "The methods annotated with " +
                             "$annotationName can't be private as Showkase won't be able to access " +
@@ -62,7 +62,7 @@ internal class ShowkaseValidator {
             }
             // Validate that only a single parameter is passed to these functions. In addition, 
             // the parameter should be annotated with @PreviewParameter.
-            element.isMethod() && validateComposableParameter(element) -> {
+            validateComposableParameter(element) -> {
                 throw ShowkaseProcessorException(
                     "Make sure that the @Composable functions that you annotate with" +
                             " the $annotationName annotation only have a single parameter that is" +

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -16,9 +16,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 import com.airbnb.android.showkase.annotation.ShowkaseScreenshot
 import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.COMPOSABLE_SIMPLE_NAME
-import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.METADATA_SIMPLE_NAME
 import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.PREVIEW_PARAMETER_SIMPLE_NAME
-import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.PREVIEW_SIMPLE_NAME
 import com.airbnb.android.showkase.processor.exceptions.ShowkaseProcessorException
 import com.airbnb.android.showkase.processor.models.ShowkaseMetadata
 import com.airbnb.android.showkase.processor.models.isJavac
@@ -78,10 +76,8 @@ internal class ShowkaseValidator {
     }
 
     // This should check if it is an annotation with multiple @Preview annotations
-    private fun checkElementIsMultiPreview(element: XElement): Boolean {
-       return element.getAllAnnotations().size >= 2 && element.findAnnotationBySimpleName(
-                PREVIEW_SIMPLE_NAME) != null && element.findAnnotationBySimpleName(
-           METADATA_SIMPLE_NAME) == null
+    internal fun checkElementIsMultiPreview(element: XElement): Boolean {
+        return element.isTypeElement() && element.isAnnotationClass()
     }
 
     // We only allow composable functions who's previews meet the following criteria:

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -16,6 +16,7 @@ import com.airbnb.android.showkase.annotation.ShowkaseRoot
 import com.airbnb.android.showkase.annotation.ShowkaseRootModule
 import com.airbnb.android.showkase.annotation.ShowkaseScreenshot
 import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.COMPOSABLE_SIMPLE_NAME
+import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.METADATA_SIMPLE_NAME
 import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.PREVIEW_PARAMETER_SIMPLE_NAME
 import com.airbnb.android.showkase.processor.ShowkaseProcessor.Companion.PREVIEW_SIMPLE_NAME
 import com.airbnb.android.showkase.processor.exceptions.ShowkaseProcessorException
@@ -40,7 +41,7 @@ internal class ShowkaseValidator {
         }
 
         when {
-            !element.isMethod() && !checkElementIsMultiPreview(element, annotationName) -> {
+            !element.isMethod() && !checkElementIsMultiPreview(element) -> {
                 throw ShowkaseProcessorException(
                     "Only composable methods can be annotated with $annotationName",
                     element
@@ -76,9 +77,11 @@ internal class ShowkaseValidator {
         }
     }
 
-    private fun checkElementIsMultiPreview(element: XElement, annotationName: String): Boolean {
+    // This should check if it is an annotation with multiple @Preview annotations
+    private fun checkElementIsMultiPreview(element: XElement): Boolean {
        return element.getAllAnnotations().size >= 2 && element.findAnnotationBySimpleName(
-                PREVIEW_SIMPLE_NAME) != null
+                PREVIEW_SIMPLE_NAME) != null && element.findAnnotationBySimpleName(
+           METADATA_SIMPLE_NAME) == null
     }
 
     // We only allow composable functions who's previews meet the following criteria:

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -75,7 +75,7 @@ internal class ShowkaseValidator {
         }
     }
 
-    // This should check if it is an annotation with multiple @Preview annotations
+    // This should check if it is an annotation that's annotated with @Preview annotation
     internal fun checkElementIsMultiPreview(element: XElement): Boolean {
         return element.isTypeElement() && element.isAnnotationClass()
     }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -3,7 +3,6 @@ package com.airbnb.android.showkase.processor.models
 import androidx.room.compiler.processing.XAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XElement
-import androidx.room.compiler.processing.XExecutableElement
 import androidx.room.compiler.processing.XFieldElement
 import androidx.room.compiler.processing.XMemberContainer
 import androidx.room.compiler.processing.XMethodElement

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -3,6 +3,7 @@ package com.airbnb.android.showkase.processor.models
 import androidx.room.compiler.processing.XAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XExecutableElement
 import androidx.room.compiler.processing.XFieldElement
 import androidx.room.compiler.processing.XMemberContainer
 import androidx.room.compiler.processing.XMethodElement


### PR DESCRIPTION
This is the first PR in order for Showkase to support multi-preview annotations (annotations annotated with `@Preview`)(#233)

In this PR I have only made sure that consumers that are using multi-preview annotations can also use Showkase without compiletime failures. If the annotation processor faces such an issue, it will just skip it for now.

Leaving this as draft, as I have some questions about the validator function 😅 