### PR TITLE
Update Readme badge to show correct compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Showkase
-![Showkase Version](https://img.shields.io/badge/Showkase-1.0.0--beta14-brightgreen) ![Compatible with Compose](https://img.shields.io/badge/Compatible%20with%20Compose-1.1.1-brightgreen)
+![Showkase Version](https://img.shields.io/badge/Showkase-1.0.0--beta14-brightgreen) ![Compatible with Compose](https://img.shields.io/badge/Compatible%20with%20Compose-1.2.0-brightgreen)
 
 Showkase is an annotation-processor based Android library that helps you organize, discover, search 
 and visualize [Jetpack Compose](https://developer.android.com/jetpack/compose) UI elements. With 


### PR DESCRIPTION
Since we merged https://github.com/airbnb/Showkase/pull/249 bumping to the stable version 1.2.0 of compose, I think we should update the badge showing which version of compose we are compatible with 😄  This PR updates the badge 😄 