### PR TITLE
Make stacked preview annotations generate showkaseMetadata components for each annotation

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -DuseKsp=false
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=false -DuseKsp=false
 
       - name: Run UI Tests w/ KSP
         uses: reactivecircus/android-emulator-runner@v2
@@ -65,7 +65,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -DuseKsp=true
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true -DuseKsp=true
 
       - name: Run Screenshot Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=false -DuseKsp=false
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=false
 
       - name: Run UI Tests w/ KSP
         uses: reactivecircus/android-emulator-runner@v2
@@ -65,7 +65,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true -DuseKsp=true
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true
 
       - name: Run Screenshot Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,7 +56,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=false
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -DuseKsp=false
 
       - name: Run UI Tests w/ KSP
         uses: reactivecircus/android-emulator-runner@v2
@@ -65,7 +65,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true
+          script: ./gradlew connectedCheck --no-daemon --stacktrace -DuseKsp=true
 
       - name: Run Screenshot Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ to understand the behavior when you don't pass any properties.
 **Note:** Make sure that you add this annotation to only those functions that meet the following criteria:
 - Functions that don't have any parameters
 - If it does have a parameter, it has to be annotated with `@PreviewParameter` that is provided a `PreviewParameterProvider` implementation.
-- Stacked `@Preview` annotations are only supported with KSP at the moment. This is because of this [issue](https://youtrack.jetbrains.com/issue/KT-49682).
+- Stacked `@Preview` and `ShowkaseComposable` annotations are only supported with KSP at the moment. This is because of this [issue](https://youtrack.jetbrains.com/issue/KT-49682).
 
 This is identical to how `@Preview` works in Compose as well so Showkase just adheres to the same rules. 
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ to understand the behavior when you don't pass any properties.
 **Note:** Make sure that you add this annotation to only those functions that meet the following criteria:
 - Functions that don't have any parameters
 - If it does have a parameter, it has to be annotated with `@PreviewParameter` that is provided a `PreviewParameterProvider` implementation.
+- Stacked `@Preview` annotations are only supported with KSP at the moment. This is because of this [issue](https://youtrack.jetbrains.com/issue/KT-49682).
 
 This is identical to how `@Preview` works in Compose as well so Showkase just adheres to the same rules. 
 

--- a/sample/src/main/java/com/airbnb/android/showkasesample/BasicChip.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/BasicChip.kt
@@ -57,3 +57,14 @@ fun BasicChipBluePreview() {
         modifier = Modifier.background(color = Color.Blue)
     )
 }
+
+
+@ShowkaseComposable(name = "Basic Chip Grey Light", group = "Chips")
+@ShowkaseComposable(name = "Basic Chip Grey Dark", group = "Chips")
+@Composable
+fun BasicChipGreyPreview() {
+    BasicChip(
+        text = "Chip Component",
+        modifier = Modifier.background(color = Color.Gray)
+    )
+}

--- a/sample/src/main/java/com/airbnb/android/showkasesample/BasicChip.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/BasicChip.kt
@@ -1,5 +1,7 @@
 package com.airbnb.android.showkasesample
 
+import android.content.res.Configuration.UI_MODE_NIGHT_NO
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -9,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 
@@ -42,5 +45,15 @@ fun BasicChipYellowPreview() {
     BasicChip(
         text = "Chip Component",
         modifier = Modifier.background(color = Color.Yellow)
+    )
+}
+
+@Preview(name = "Basic Chip Blue Light", group = "Chips", uiMode = UI_MODE_NIGHT_NO)
+@Preview(name = "Basic Chip Blue Dark", group = "Chips", uiMode = UI_MODE_NIGHT_YES)
+@Composable
+fun BasicChipBluePreview() {
+    BasicChip(
+        text = "Chip Component",
+        modifier = Modifier.background(color = Color.Blue)
     )
 }

--- a/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ShowkaseComposable.kt
+++ b/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ShowkaseComposable.kt
@@ -57,6 +57,7 @@ package com.airbnb.android.showkase.annotation
 @MustBeDocumented
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION)
+@Repeatable
 @Suppress("LongParameterList")
 annotation class ShowkaseComposable(
     val name: String = "",

--- a/showkase-browser-testing/build.gradle
+++ b/showkase-browser-testing/build.gradle
@@ -20,6 +20,7 @@ android {
         exclude 'META-INF/gradle/incremental.annotation.processors'
         exclude("META-INF/*.kotlin_module")
     }
+
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 32
@@ -28,6 +29,12 @@ android {
         // "pm clear" command after each test invocation. This command ensures
         // that the app's state is completely cleared between tests.
         testInstrumentationRunnerArguments clearPackageData: 'true'
+        
+        if (project.hasProperty('useKsp')) {
+            buildConfigField "boolean", "IS_RUNNING_KSP", "true"
+        } else {
+            buildConfigField "boolean", "IS_RUNNING_KSP", "false"
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -47,6 +47,11 @@ class ShowcaseBrowserTest {
         7
     }
 
+    @Before
+    fun setupLog() {
+        println("Use KSP value = ${System.getProperty("useKsp")}")
+    }
+
     @Test
     fun activity_starts_and_all_the_showkase_ui_elements_are_visible_on_the_screen_and_clickable() {
         // Assert that all the categories are displayed on the screen and that they are clickable.

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -6,7 +6,6 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.ui.ShowkaseBrowserActivity
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,15 +40,10 @@ class ShowcaseBrowserTest {
     // beyond the source retention KEEP, except for in the new IR backend which was introduced
     // in Kotlin 1.6. It will be available in the old backend in Kotlin version 1.7.20.
     // See https://youtrack.jetbrains.com/issue/KT-49682 for more information about this.
-    private val componentSize = if (System.getProperty("useKsp") == "true") {
+    private val componentSize = if (BuildConfig.IS_RUNNING_KSP) {
         11
     } else {
         7
-    }
-
-    @Before
-    fun setupLog() {
-        println("Use KSP value = ${System.getProperty("useKsp")}")
     }
 
     @Test
@@ -92,7 +86,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Tap on the "Colors" row
             clickRowWithText("Colors (4)")
@@ -109,7 +104,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Tap on the "Typography" row
             clickRowWithText("Typography (13)")
@@ -193,7 +189,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Tap on the "Colors" row
             clickRowWithText("Colors (4)")
@@ -213,7 +210,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Tap on the "Typography" row
             clickRowWithText("Typography (13)")
@@ -242,7 +240,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Select Components
             clickRowWithText("Components ($componentSize)")
@@ -267,7 +266,8 @@ class ShowcaseBrowserTest {
             verifyLandingScreen(
                 components = componentSize,
                 typography = 13,
-                colors = 4,)
+                colors = 4,
+            )
 
             // Select Colors
             clickRowWithText("Colors (4)")

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -37,6 +37,10 @@ class ShowcaseBrowserTest {
         )
 
     // This will alter now since KSP supports stacked preview annotations and KAPT does not.
+    // It is not supported in KAPT because there is no support for repeatable annotations in KAPT
+    // beyond the source retention KEEP, except for in the new IR backend which was introduced
+    // in Kotlin 1.6. It will be available in the old backend in Kotlin version 1.7.20.
+    // See https://youtrack.jetbrains.com/issue/KT-49682 for more information about this.
     private val componentSize = if (System.getProperty("useKsp") == "true") {
         11
     } else {

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -652,7 +652,7 @@ class ShowcaseBrowserTest {
     @Test
     fun stacked_preview_show_up_in_browser() {
         // Stacked previews are only supported from ksp, so this is to bypass kapt on CI
-        if (System.getProperty("useKsp") == "true") {
+        if (BuildConfig.IS_RUNNING_KSP) {
             composeTestRule.apply {
 
                 verifyLandingScreen(

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -1,13 +1,12 @@
 package com.airbnb.android.showkase_browser_testing
 
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performGesture
-import androidx.compose.ui.test.swipeDown
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.ui.ShowkaseBrowserActivity
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,23 +36,43 @@ class ShowcaseBrowserTest {
             }
         )
 
+    // This will alter now since KSP supports stacked preview annotations and KAPT does not.
+    private val componentSize = if (System.getProperty("useKsp") == "true") {
+        11
+    } else {
+        7
+    }
+
     @Test
     fun activity_starts_and_all_the_showkase_ui_elements_are_visible_on_the_screen_and_clickable() {
         // Assert that all the categories are displayed on the screen and that they are clickable.
-        composeTestRule.verifyLandingScreen()
+        composeTestRule.verifyLandingScreen(
+            components = componentSize,
+            typography = 13,
+            colors = 4,
+        )
     }
 
     @Test
     fun clicking_components_takes_you_to_a_screen_with_groups_of_components() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Tap on the "Components" row
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Verify that all the groups are displayed on the screen
-            verifyRowsWithTextAreDisplayed("Group1 (2)", "Group2 (1)", "Group3 (2)", "Submodule (1)")
+            verifyRowsWithTextAreDisplayed(
+                "Group1 (2)",
+                "Group2 (1)",
+                "Group3 (2)",
+                "Submodule (1)"
+            )
         }
     }
 
@@ -61,7 +80,10 @@ class ShowcaseBrowserTest {
     fun clicking_colors_takes_you_to_a_screen_with_groups_of_colors() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Tap on the "Colors" row
             clickRowWithText("Colors (4)")
@@ -75,7 +97,10 @@ class ShowcaseBrowserTest {
     fun clicking_typography_takes_you_to_a_screen_with_groups_of_typography() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Tap on the "Typography" row
             clickRowWithText("Typography (13)")
@@ -89,10 +114,14 @@ class ShowcaseBrowserTest {
     fun opening_component_detail_screen_has_5_permutations_displayed() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Tap on the "Components" row
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Select "Group1"
             clickRowWithText("Group1 (2)")
@@ -152,7 +181,10 @@ class ShowcaseBrowserTest {
     fun selecting_color_group_has_colors_displayed() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Tap on the "Colors" row
             clickRowWithText("Colors (4)")
@@ -169,7 +201,10 @@ class ShowcaseBrowserTest {
     fun selecting_typography_group_has_colors_displayed() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Tap on the "Typography" row
             clickRowWithText("Typography (13)")
@@ -195,10 +230,13 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_groups_of_components() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Select Components
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Tap on the search icon
             clickRowWithTag("SearchIcon")
@@ -217,7 +255,10 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_groups_of_colors() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,)
 
             // Select Colors
             clickRowWithText("Colors (4)")
@@ -237,7 +278,11 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_groups_of_typography() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select Typography
             clickRowWithText("Typography (13)")
@@ -259,10 +304,14 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_components() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select components
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Select Group 3
             clickRowWithText("Group3 (2)")
@@ -287,7 +336,11 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_colors() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select "Colors"
             clickRowWithText("Colors (4)")
@@ -315,7 +368,11 @@ class ShowcaseBrowserTest {
     fun entering_text_in_search_bar_filters_the_visible_typography() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select "Typography"
             clickRowWithText("Typography (13)")
@@ -341,8 +398,10 @@ class ShowcaseBrowserTest {
             // Ensure that only "Body1" & "Body2" is visible on the screen. The rest of the groups should
             // not be visble anymore
             verifyRowsWithTextAreDisplayed("Body1", "Body2")
-            verifyRowsWithTextDoesNotExist("H1", "H2", "H3", "H4", "H5", "H6", "Subtitle1",
-                "Subtitle2")
+            verifyRowsWithTextDoesNotExist(
+                "H1", "H2", "H3", "H4", "H5", "H6", "Subtitle1",
+                "Subtitle2"
+            )
         }
     }
 
@@ -350,14 +409,18 @@ class ShowcaseBrowserTest {
     fun navigating_to_component_leaf_screen_and_back_works_ok() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select components to go to the component groups screen
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Click on "Group 1" to go to the components in a group screen
             clickRowWithText("Group1 (2)")
-            
+
             // Click on "Test Composable1" to go to the component styles screen
             clickRowWithText("Test Composable1")
 
@@ -393,7 +456,11 @@ class ShowcaseBrowserTest {
             goBack()
 
             // Confirm that we are in the right screen
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
         }
     }
 
@@ -401,7 +468,11 @@ class ShowcaseBrowserTest {
     fun navigating_to_color_leaf_screen_and_back_works_ok() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select "Colors" to go to the color groups screen
             clickRowWithText("Colors (4)")
@@ -422,7 +493,11 @@ class ShowcaseBrowserTest {
             goBack()
 
             // Confirm that we are in the right screen
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
         }
     }
 
@@ -430,7 +505,11 @@ class ShowcaseBrowserTest {
     fun navigating_to_typography_leaf_screen_and_back_works_ok() {
         composeTestRule.apply {
             // Ensure all the categories are visible
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Select "Typography" to go to the typography groups screen
             clickRowWithText("Typography (13)")
@@ -451,7 +530,11 @@ class ShowcaseBrowserTest {
             goBack()
 
             // Confirm that we are in the right screen
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
         }
     }
 
@@ -459,10 +542,14 @@ class ShowcaseBrowserTest {
     fun components_with_long_names_have_a_correct_top_app_bar() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Tap on the "Components" row
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Select "Group4"
             clickRowWithText("Group4 (1)")
@@ -481,10 +568,14 @@ class ShowcaseBrowserTest {
     fun search_field_has_enabled_close_button() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Tap on the "Components" row
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             // Tap on the search icon
             clickRowWithTag("SearchIcon")
@@ -508,10 +599,14 @@ class ShowcaseBrowserTest {
     fun clear_search_field_clears_the_field() {
         composeTestRule.apply {
             // Assert that all the categories are displayed on the screen and that they are clickable.
-            verifyLandingScreen()
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
 
             // Tap on the "Components" row
-            clickRowWithText("Components (7)")
+            clickRowWithText("Components ($componentSize)")
 
             waitForIdle()
 
@@ -542,6 +637,36 @@ class ShowcaseBrowserTest {
 
             // Check that the search icon is displayed again
             verifyButtonWithTagIsDisplayedAndEnabled("SearchIcon")
+        }
+    }
+
+    @Test
+    fun stacked_preview_show_up_in_browser() {
+        // Stacked previews are only supported from ksp, so this is to bypass kapt on CI
+        if (System.getProperty("useKsp") == "true") {
+            composeTestRule.apply {
+
+                verifyLandingScreen(
+                    components = 11,
+                    typography = 13,
+                    colors = 4,
+                )
+                // Tap on the "Components" row
+                clickRowWithText("Components (11)")
+
+                waitForIdle()
+
+                clickRowWithText("Group7 (4)")
+
+                waitForIdle()
+
+                // Verify that they are all displayed and treated as different components
+                onNodeWithText("Composable7").assertIsDisplayed()
+                onNodeWithText("Composable8").assertIsDisplayed()
+                onNodeWithText("Composable9").assertIsDisplayed()
+                onNodeWithText("Composable10").assertIsDisplayed()
+
+            }
         }
     }
 }

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTestFlows.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTestFlows.kt
@@ -79,8 +79,12 @@ internal fun <T : ComponentActivity> AndroidComposeTestRule<ActivityScenarioRule
         it.onBackPressed()
     }
 
-internal fun AndroidComposeTestRule<ActivityScenarioRule<ShowkaseBrowserActivity>, ShowkaseBrowserActivity>.verifyLandingScreen() {
-    verifyRowsWithTextAreDisplayed("Components (7)", "Typography (13)", "Colors (4)")
+internal fun AndroidComposeTestRule<ActivityScenarioRule<ShowkaseBrowserActivity>, ShowkaseBrowserActivity>.verifyLandingScreen(
+    components: Int,
+    typography: Int,
+    colors: Int,
+) {
+    verifyRowsWithTextAreDisplayed("Components ($components)", "Typography ($typography)", "Colors ($colors)")
 }
 
 internal fun AndroidComposeTestRule<ActivityScenarioRule<ShowkaseBrowserActivity>, ShowkaseBrowserActivity>.verifyTypographyDetailScreen() {

--- a/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
+++ b/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
@@ -53,6 +53,20 @@ class WrapperComposableClass {
     }
 }
 
+@ShowkaseComposable("Composable7", "Group7")
+@ShowkaseComposable("Composable8", "Group7")
+@Composable
+fun TestComposable7() {
+    BasicText(text = "Test Composable7and8")
+}
+
+@Preview("Composable9", "Group7")
+@Preview("Composable10", "Group7")
+@Composable
+fun TestComposable8() {
+    BasicText(text = "Test Composable9and10")
+}
+
 // Adding this to see on the UI tests that this compiles.
 // Will remove it when we actually supports MultiPreviewAnnotations.
 @Preview(

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
@@ -71,8 +71,10 @@ abstract class BaseProcessorTest {
         }
     }
 
-    protected fun compileInputsAndVerifyOutputs() {
-        compileInputs { mode, compilation, result ->
+    protected fun compileInputsAndVerifyOutputs(
+        modes:List<Mode> = listOf(Mode.KSP, Mode.KAPT)
+    ) {
+        compileInputs(modes = modes) { mode, compilation, result ->
             result.assertGeneratedSources(mode, compilation)
         }
     }

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
@@ -514,5 +514,11 @@ class ShowkaseProcessorTest : BaseProcessorTest() {
         // This functionality is only supported with KSP for now.
         compileInputsAndVerifyOutputs(modes = listOf(Mode.KSP))
     }
+
+    @Test
+    fun `composable function with multiple showkasecomposable annotations stacked generates output`() {
+        // This functionality is only supported with KSP for now.
+        compileInputsAndVerifyOutputs(modes = listOf(Mode.KSP))
+    }
 }
 

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
@@ -508,5 +508,10 @@ class ShowkaseProcessorTest : BaseProcessorTest() {
     fun `composable function with multiple preview functions compiles`() {
         compileInputsAndVerifyOutputs()
     }
+
+    @Test
+    fun `composable function with multiple preview annotations stacked generates output`() {
+        compileInputsAndVerifyOutputs()
+    }
 }
 

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
@@ -511,7 +511,8 @@ class ShowkaseProcessorTest : BaseProcessorTest() {
 
     @Test
     fun `composable function with multiple preview annotations stacked generates output`() {
-        compileInputsAndVerifyOutputs()
+        // This functionality is only supported with KSP for now.
+        compileInputsAndVerifyOutputs(modes = listOf(Mode.KSP))
     }
 }
 

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name1",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_group1_name1_null""",
+                """com.airbnb.android.showkase_processor_testing_null_group1_name1_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable1() }),
         ShowkaseBrowserComponent(
@@ -31,7 +31,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name2",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_group2_name2_null""",
+                """com.airbnb.android.showkase_processor_testing_null_group2_name2_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable2() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable1",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_WrapperClass_TestComposable1_null""",
+                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_WrapperClass_TestComposable1_0_null""",
             isDefaultStyle = false,
             component = @Composable {
                 WrapperClass().TestComposable1()
@@ -40,7 +40,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "TestComposable2",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposable2(text = previewParam) }
                       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null""",
+                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable {
                 WrapperClass().TestComposable()

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null""",
+                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable {
                 WrapperClass.TestComposable()

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null""",
+                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable {
                 WrapperClass.TestComposable()

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootCodegen.kt
@@ -29,7 +29,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "name",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_null_group_name_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_null_group_name_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposableWithDefaultParameters(bankHeader =
                               previewParam) }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,19 +19,4 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
   )
   public fun group2name2(): Unit {
   }
-
-  @ShowkaseCodegenMetadata(
-    showkaseName = "name1",
-    showkaseGroup = "group1",
-    packageName = "com.airbnb.android.showkase_processor_testing",
-    packageSimpleName = "showkase_processor_testing",
-    showkaseElementName = "TestComposable1",
-    insideObject = false,
-    insideWrapperClass = false,
-    showkaseKDoc = "",
-    showkaseMetadataType = "COMPONENT",
-    isDefaultStyle = false,
-  )
-  public fun group1name1(): Unit {
-  }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_both_annotations_gives_priority_to_showkase_annotation/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -19,4 +19,19 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
   )
   public fun group2name2(): Unit {
   }
+
+  @ShowkaseCodegenMetadata(
+    showkaseName = "name1",
+    showkaseGroup = "group1",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "TestComposable1",
+    insideObject = false,
+    insideWrapperClass = false,
+    showkaseKDoc = "",
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+  )
+  public fun group1name1(): Unit {
+  }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootCodegen.kt
@@ -32,7 +32,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             | ```
             """.trimMargin(),
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null""",
+                """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable {
                 WrapperClass.TestComposable()

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/input/Composables.kt
@@ -1,0 +1,21 @@
+package com.airbnb.android.showkase_processor_testing
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties.Text
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "small font",
+    group = "font scales",
+    fontScale = 0.5f
+)
+@Preview(
+    name = "large font",
+    group = "font scales",
+    fontScale = 1.5f
+)
+@Composable
+public fun ComposablePreviewFont() {
+
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -6,6 +6,7 @@ import kotlin.Unit
 
 public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
   @ShowkaseCodegenMetadata(
+    showkaseName = "small font",
     showkaseGroup = "font scales",
     packageName = "com.airbnb.android.showkase_processor_testing",
     packageSimpleName = "showkase_processor_testing",
@@ -13,14 +14,14 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseName = "ComposablePreviewFont_0",
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
   )
-  public fun fontscalesComposablePreviewFont0(): Unit {
+  public fun fontscalessmallfont(): Unit {
   }
 
   @ShowkaseCodegenMetadata(
+    showkaseName = "large font",
     showkaseGroup = "font scales",
     packageName = "com.airbnb.android.showkase_processor_testing",
     packageSimpleName = "showkase_processor_testing",
@@ -28,10 +29,9 @@ public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
     insideObject = false,
     insideWrapperClass = false,
     showkaseKDoc = "",
-    showkaseName = "ComposablePreviewFont_1",
     showkaseMetadataType = "COMPONENT",
     isDefaultStyle = false,
   )
-  public fun fontscalesComposablePreviewFont1(): Unit {
+  public fun fontscaleslargefont1(): Unit {
   }
 }

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_preview_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -1,0 +1,37 @@
+// This is an auto-generated file. Please do not edit/modify this file.
+package com.airbnb.android.showkase
+
+import com.airbnb.android.showkase.`annotation`.ShowkaseCodegenMetadata
+import kotlin.Unit
+
+public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
+  @ShowkaseCodegenMetadata(
+    showkaseGroup = "font scales",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "ComposablePreviewFont",
+    insideObject = false,
+    insideWrapperClass = false,
+    showkaseKDoc = "",
+    showkaseName = "ComposablePreviewFont_0",
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+  )
+  public fun fontscalesComposablePreviewFont0(): Unit {
+  }
+
+  @ShowkaseCodegenMetadata(
+    showkaseGroup = "font scales",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "ComposablePreviewFont",
+    insideObject = false,
+    insideWrapperClass = false,
+    showkaseKDoc = "",
+    showkaseName = "ComposablePreviewFont_1",
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+  )
+  public fun fontscalesComposablePreviewFont1(): Unit {
+  }
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_showkasecomposable_annotations_stacked_generates_output/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_showkasecomposable_annotations_stacked_generates_output/input/Composables.kt
@@ -1,0 +1,24 @@
+package com.airbnb.android.showkase_processor_testing
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties.Text
+import androidx.compose.ui.tooling.preview.Preview
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+
+@ShowkaseComposable(
+    name = "small font",
+    group = "font scales",
+    widthDp = 250,
+    heightDp = 250,
+)
+@ShowkaseComposable(
+    name = "large font",
+    group = "font scales",
+    widthDp = 200,
+    heightDp = 200,
+)
+@Composable
+public fun StackedShowkaseComposables() {
+
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_showkasecomposable_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_multiple_showkasecomposable_annotations_stacked_generates_output/output/ShowkaseMetadata_com_airbnb_android_showkase_processor_testing.kt
@@ -1,0 +1,41 @@
+// This is an auto-generated file. Please do not edit/modify this file.
+package com.airbnb.android.showkase
+
+import com.airbnb.android.showkase.`annotation`.ShowkaseCodegenMetadata
+import kotlin.Unit
+
+public class ShowkaseMetadata_com_airbnb_android_showkase_processor_testing {
+  @ShowkaseCodegenMetadata(
+    showkaseName = "small font",
+    showkaseGroup = "font scales",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "StackedShowkaseComposables",
+    insideObject = false,
+    insideWrapperClass = false,
+    showkaseKDoc = "",
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+    showkaseWidthDp = 250,
+    showkaseHeightDp = 250,
+  )
+  public fun fontscalessmallfont(): Unit {
+  }
+
+  @ShowkaseCodegenMetadata(
+    showkaseName = "large font",
+    showkaseGroup = "font scales",
+    packageName = "com.airbnb.android.showkase_processor_testing",
+    packageSimpleName = "showkase_processor_testing",
+    showkaseElementName = "StackedShowkaseComposables",
+    insideObject = false,
+    insideWrapperClass = false,
+    showkaseKDoc = "",
+    showkaseMetadataType = "COMPONENT",
+    isDefaultStyle = false,
+    showkaseWidthDp = 200,
+    showkaseHeightDp = 200,
+  )
+  public fun fontscaleslargefont1(): Unit {
+  }
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_previews_with_multiple_parameter_providers_should_indent_properly/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_previews_with_multiple_parameter_providers_should_indent_properly/output/TestShowkaseRootCodegen.kt
@@ -34,7 +34,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                               "Composable1 Usage of an integer preview parameter provider",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_browser_testing_null_Group1_Composable1Usageofanintegerpreviewparameterprovider_null_$index""",
+                              """com.airbnb.android.showkase_browser_testing_null_Group1_Composable1Usageofanintegerpreviewparameterprovider_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposable1(n = previewParam) }
                       )
@@ -51,7 +51,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "Composable2 Usage of a char preview parameter provider",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_browser_testing_null_Group1_Composable2Usageofacharpreviewparameterprovider_null_$index""",
+                              """com.airbnb.android.showkase_browser_testing_null_Group1_Composable2Usageofacharpreviewparameterprovider_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposable2(c = previewParam) }
                       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootCodegen.kt
@@ -29,7 +29,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "name",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable {
                               WrapperClass.TestComposable(text = previewParam)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootCodegen.kt
@@ -29,7 +29,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "name",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_my_very_long_name_com.airbnb.android.showkase_processor_testing_my_very_long_name.WrapperClass_group_name_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_my_very_long_name_com.airbnb.android.showkase_processor_testing_my_very_long_name.WrapperClass_group_name_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable {
                               WrapperClass.TestComposable(text = previewParam)

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_component_name_null""",
+                """com.airbnb.android.showkase_processor_testing_null_component_name_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name1",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_group1_name1_null""",
+                """com.airbnb.android.showkase_processor_testing_null_group1_name1_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable1() }),
         ShowkaseBrowserComponent(
@@ -31,7 +31,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name2",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_group2_name2_null""",
+                """com.airbnb.android.showkase_processor_testing_null_group2_name2_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable2() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -22,7 +22,8 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             group = "group",
             componentName = "name",
             componentKDoc = "",
-            componentKey = """com.airbnb.android.showkase_processor_testing_null_group_name_null""",
+            componentKey =
+                """com.airbnb.android.showkase_processor_testing_null_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -22,7 +22,8 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             group = "group",
             componentName = "name",
             componentKDoc = "",
-            componentKey = """com.airbnb.android.showkase_processor_testing_null_group_name_null""",
+            componentKey =
+                """com.airbnb.android.showkase_processor_testing_null_group_name_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
+                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       ).apply {
@@ -38,7 +38,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "TestComposable2",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposable2(text = previewParam) }
                       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
+                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_group_TestComposable_null""",
+                """com.airbnb.android.showkase_processor_testing_null_group_TestComposable_0_null""",
             isDefaultStyle = false,
             component = @Composable { testComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
+                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "TestComposable",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_null""",
+                """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       ).apply {
@@ -38,7 +38,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "TestComposable2",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_null_DefaultGroup_TestComposable2_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable { TestComposable2(text = previewParam) }
                       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootCodegen.kt
@@ -23,7 +23,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
             componentName = "name",
             componentKDoc = "",
             componentKey =
-                """com.airbnb.android.showkase_processor_testing_null_component_name_null""",
+                """com.airbnb.android.showkase_processor_testing_null_component_name_0_null""",
             isDefaultStyle = false,
             component = @Composable { TestComposable() })
       )

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootCodegen.kt
@@ -29,7 +29,7 @@ public class TestShowkaseRootCodegen : ShowkaseProvider {
                           componentName = "name",
                           componentKDoc = "",
                           componentKey =
-                              """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_null_$index""",
+                              """com.airbnb.android.showkase_processor_testing_com.airbnb.android.showkase_processor_testing.WrapperClass_group_name_0_null_$index""",
                           isDefaultStyle = false,
                           component = @Composable {
                               WrapperClass().TestComposable(text = previewParam)

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -83,6 +83,8 @@ class ShowkaseProcessor @JvmOverloads constructor(
     ): Set<ShowkaseMetadata.Component> {
         return roundEnvironment.getElementsAnnotatedWith(ShowkaseComposable::class)
             .mapNotNull { element ->
+                if (showkaseValidator.checkElementIsAnnotationClass(element)) return@mapNotNull null
+
                 showkaseValidator.validateComponentElement(
                     element,
                     ShowkaseComposable::class.java.simpleName
@@ -91,15 +93,14 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     element = element,
                     showkaseValidator = showkaseValidator,
                 )
-            }.toSet()
+            }.flatten().mapNotNull { it }.toSet()
     }
 
 
     private fun processPreviewAnnotation(roundEnvironment: XRoundEnv): Set<ShowkaseMetadata.Component> {
-        // TODO: Look into making this easier
         return roundEnvironment.getElementsAnnotatedWith(PREVIEW_CLASS_NAME)
             .mapNotNull { element ->
-                if (showkaseValidator.checkElementIsMultiPreview(element)) return@mapNotNull null
+                if (showkaseValidator.checkElementIsAnnotationClass(element)) return@mapNotNull null
                 showkaseValidator.validateComponentElement(
                     element,
                     PREVIEW_SIMPLE_NAME

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -96,6 +96,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
 
 
     private fun processPreviewAnnotation(roundEnvironment: XRoundEnv): Set<ShowkaseMetadata.Component> {
+        // TODO: Look into making this easier
         return roundEnvironment.getElementsAnnotatedWith(PREVIEW_CLASS_NAME)
             .mapNotNull { element ->
                 if (showkaseValidator.checkElementIsMultiPreview(element)) return@mapNotNull null
@@ -109,7 +110,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     showkaseValidator = showkaseValidator
                 )
 
-            }.toSet()
+            }.flatten().mapNotNull { it }.toSet()
     }
 
     private fun writeMetadataFile(uniqueComposablesMetadata: Set<ShowkaseMetadata>) {
@@ -126,12 +127,21 @@ class ShowkaseProcessor @JvmOverloads constructor(
         // only distict method's are passed onto the next round. We do this by deduping on 
         // the combination of packageName, the wrapper class when available(otherwise it 
         // will be null) & the methodName.
-        "${it.packageName}_${it.enclosingClassName}_${it.elementName}"
+        if (it.componentIndex != null) {
+            "${it.packageName}_${it.enclosingClassName}_${it.elementName}_${it.componentIndex}"
+        } else {
+
+            "${it.packageName}_${it.enclosingClassName}_${it.elementName}"
+        }
     }
         .distinctBy {
             // We also ensure that the component groupName and the component name are unique so 
-            // that they don't show up twice in the browser app. 
-            "${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}"
+            // that they don't show up twice in the browser app.
+            if (it.componentIndex != null) {
+                "${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}_${it.componentIndex}"
+            } else {
+                "${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}"
+            }
         }
         .sortedBy {
             "${it.packageName}_${it.enclosingClassName}_${it.elementName}"

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -354,7 +354,7 @@ internal class ShowkaseValidator {
     ) {
         val groupedComponents = componentsMetadata.groupBy { it.showkaseGroup }
         groupedComponents.forEach { groupEntry ->
-            val groupedByNameComponents = groupEntry.value.groupBy { it.showkaseName }
+            val groupedByNameComponents = groupEntry.value.groupBy { it.componentDistinctName }
             groupedByNameComponents.forEach { nameEntry ->
                 // Verify that there's at most 1 default style for a given component
                 if (nameEntry.value.filter { it.isDefaultStyle }.size > 1) {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -354,7 +354,7 @@ internal class ShowkaseValidator {
     ) {
         val groupedComponents = componentsMetadata.groupBy { it.showkaseGroup }
         groupedComponents.forEach { groupEntry ->
-            val groupedByNameComponents = groupEntry.value.groupBy { it.componentDistinctName }
+            val groupedByNameComponents = groupEntry.value.groupBy { it.showkaseName }
             groupedByNameComponents.forEach { nameEntry ->
                 // Verify that there's at most 1 default style for a given component
                 if (nameEntry.value.filter { it.isDefaultStyle }.size > 1) {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/logging/ShowkaseValidator.kt
@@ -75,8 +75,8 @@ internal class ShowkaseValidator {
         }
     }
 
-    // This should check if it is an annotation that's annotated with @Preview annotation
-    internal fun checkElementIsMultiPreview(element: XElement): Boolean {
+    // This should check if it is an annotation that's annotated with @Preview or @ShowkaseComposable annotation
+    internal fun checkElementIsAnnotationClass(element: XElement): Boolean {
         return element.isTypeElement() && element.isAnnotationClass()
     }
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -177,40 +177,44 @@ private fun Int.parseAnnotationProperty() = when (this) {
 internal fun getShowkaseMetadata(
     element: XMethodElement,
     showkaseValidator: ShowkaseValidator
-): ShowkaseMetadata.Component? {
-    val showkaseAnnotation = element.requireAnnotation(ShowkaseComposable::class).value
-    // If this component was configured to be skipped, return early
-    if (showkaseAnnotation.skip) return null
+): List<ShowkaseMetadata.Component?> {
+    val showkaseAnnotations = element.getAnnotations(ShowkaseComposable::class)
 
     val commonMetadata = element.extractCommonMetadata(showkaseValidator)
-    val showkaseName = getShowkaseName(showkaseAnnotation.name, element.name)
-    val showkaseGroup = getShowkaseGroup(
-        showkaseAnnotation.group,
-        commonMetadata.enclosingClass,
-    )
-    val isDefaultStyle = showkaseAnnotation.defaultStyle
-    val showkaseStyleName = getShowkaseStyleName(showkaseAnnotation.styleName, isDefaultStyle)
-
     val previewParameterMetadata = element.getPreviewParameterMetadata()
 
-    return ShowkaseMetadata.Component(
-        packageSimpleName = commonMetadata.moduleName,
-        packageName = commonMetadata.packageName,
-        enclosingClassName = commonMetadata.enclosingClassName,
-        elementName = element.name,
-        showkaseName = showkaseName,
-        showkaseGroup = showkaseGroup,
-        showkaseStyleName = showkaseStyleName,
-        showkaseWidthDp = showkaseAnnotation.widthDp.parseAnnotationProperty(),
-        showkaseHeightDp = showkaseAnnotation.heightDp.parseAnnotationProperty(),
-        insideObject = commonMetadata.showkaseFunctionType.insideObject(),
-        insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
-        element = element,
-        showkaseKDoc = commonMetadata.kDoc,
-        previewParameterName = previewParameterMetadata?.first,
-        previewParameterProviderType = previewParameterMetadata?.second,
-        isDefaultStyle = isDefaultStyle,
-    )
+    return showkaseAnnotations.mapNotNull { annotation ->
+        // If this component was configured to be skipped, return early
+        if (annotation.value.skip) return@mapNotNull null
+
+        val showkaseName = getShowkaseName(annotation.value.name, element.name)
+        val showkaseGroup = getShowkaseGroup(
+            annotation.value.group,
+            commonMetadata.enclosingClass,
+        )
+        val isDefaultStyle = annotation.value.defaultStyle
+        val showkaseStyleName = getShowkaseStyleName(annotation.value.styleName, isDefaultStyle)
+
+        ShowkaseMetadata.Component(
+            packageSimpleName = commonMetadata.moduleName,
+            packageName = commonMetadata.packageName,
+            enclosingClassName = commonMetadata.enclosingClassName,
+            elementName = element.name,
+            showkaseName = showkaseName,
+            showkaseGroup = showkaseGroup,
+            showkaseStyleName = showkaseStyleName,
+            showkaseWidthDp = annotation.value.widthDp.parseAnnotationProperty(),
+            showkaseHeightDp = annotation.value.heightDp.parseAnnotationProperty(),
+            insideObject = commonMetadata.showkaseFunctionType.insideObject(),
+            insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
+            element = element,
+            showkaseKDoc = commonMetadata.kDoc,
+            previewParameterName = previewParameterMetadata?.first,
+            previewParameterProviderType = previewParameterMetadata?.second,
+            isDefaultStyle = isDefaultStyle,
+            componentIndex = showkaseAnnotations.indexOf(annotation),
+        )
+    }
 }
 
 internal fun XMethodElement.extractCommonMetadata(showkaseValidator: ShowkaseValidator): CommonMetadata {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -52,6 +52,8 @@ internal sealed class ShowkaseMetadata {
         override val enclosingClassName: ClassName? = null,
         override val insideWrapperClass: Boolean = false,
         override val insideObject: Boolean = false,
+        val componentIndex: Int? = null,
+        val componentDistinctName: String? = null,
         val showkaseWidthDp: Int? = null,
         val showkaseHeightDp: Int? = null,
         val previewParameterProviderType: TypeName? = null,
@@ -208,7 +210,8 @@ internal fun getShowkaseMetadata(
         showkaseKDoc = commonMetadata.kDoc,
         previewParameterName = previewParameterMetadata?.first,
         previewParameterProviderType = previewParameterMetadata?.second,
-        isDefaultStyle = isDefaultStyle
+        isDefaultStyle = isDefaultStyle,
+        componentDistinctName = element.name,
     )
 }
 
@@ -251,44 +254,47 @@ internal data class CommonMetadata(
 internal fun getShowkaseMetadataFromPreview(
     element: XMethodElement,
     showkaseValidator: ShowkaseValidator,
-): ShowkaseMetadata.Component? {
-    val previewAnnotation = element.requireAnnotationBySimpleName(PREVIEW_SIMPLE_NAME)
+): List<ShowkaseMetadata.Component?> {
+    val previewAnnotations = element.requireAnnotationBySimpleName(PREVIEW_SIMPLE_NAME)
 
     val showkaseComosableAnnotation = element.getAnnotation(ShowkaseComposable::class)?.value
     // If this component was configured to be skipped, return early
-    if (showkaseComosableAnnotation != null && showkaseComosableAnnotation.skip) return null
+    if (showkaseComosableAnnotation != null && showkaseComosableAnnotation.skip) return listOf() // Will be mapped out
+    return previewAnnotations.mapIndexed { index, annotation ->
+        val commonMetadata = element.extractCommonMetadata(showkaseValidator)
+        val showkaseName = getShowkaseName(
+            annotation.getAsString("name"),
+            element.name
+        )
+        val showkaseGroup = getShowkaseGroup(
+            annotation.getAsString("group"),
+            commonMetadata.enclosingClass,
+        )
 
-    val commonMetadata = element.extractCommonMetadata(showkaseValidator)
-    val showkaseName = getShowkaseName(
-        previewAnnotation.getAsString("name"),
-        element.name
-    )
-    val showkaseGroup = getShowkaseGroup(
-        previewAnnotation.getAsString("group"),
-        commonMetadata.enclosingClass,
-    )
+        val width = annotation.getAsInt("widthDp")
+        val height = annotation.getAsInt("heightDp")
 
-    val width = previewAnnotation.getAsInt("widthDp")
-    val height = previewAnnotation.getAsInt("heightDp")
+        val previewParameterMetadata = element.getPreviewParameterMetadata()
 
-    val previewParameterMetadata = element.getPreviewParameterMetadata()
-
-    return ShowkaseMetadata.Component(
-        packageSimpleName = commonMetadata.moduleName,
-        packageName = commonMetadata.packageName,
-        enclosingClassName = commonMetadata.enclosingClassName,
-        elementName = element.name,
-        showkaseKDoc = commonMetadata.kDoc,
-        showkaseName = showkaseName,
-        showkaseGroup = showkaseGroup,
-        showkaseWidthDp = if (width == -1) null else width,
-        showkaseHeightDp = if (height == -1) null else width,
-        insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
-        insideObject = commonMetadata.showkaseFunctionType.insideObject(),
-        element = element,
-        previewParameterName = previewParameterMetadata?.first,
-        previewParameterProviderType = previewParameterMetadata?.second
-    )
+        ShowkaseMetadata.Component(
+            packageSimpleName = commonMetadata.moduleName,
+            packageName = commonMetadata.packageName,
+            enclosingClassName = commonMetadata.enclosingClassName,
+            elementName = element.name,
+            showkaseKDoc = commonMetadata.kDoc,
+            showkaseName = showkaseName,
+            showkaseGroup = showkaseGroup,
+            showkaseWidthDp = if (width == -1) null else width,
+            showkaseHeightDp = if (height == -1) null else width,
+            insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
+            insideObject = commonMetadata.showkaseFunctionType.insideObject(),
+            element = element,
+            previewParameterName = previewParameterMetadata?.first,
+            previewParameterProviderType = previewParameterMetadata?.second,
+            componentIndex = index,
+            componentDistinctName =  "${element.name}_$index"
+        )
+    }
 }
 
 private fun XMethodElement.getPreviewParameterMetadata(): Pair<String, TypeName>? {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -53,7 +53,6 @@ internal sealed class ShowkaseMetadata {
         override val insideWrapperClass: Boolean = false,
         override val insideObject: Boolean = false,
         val componentIndex: Int? = null,
-        val componentDistinctName: String? = null,
         val showkaseWidthDp: Int? = null,
         val showkaseHeightDp: Int? = null,
         val previewParameterProviderType: TypeName? = null,
@@ -211,7 +210,6 @@ internal fun getShowkaseMetadata(
         previewParameterName = previewParameterMetadata?.first,
         previewParameterProviderType = previewParameterMetadata?.second,
         isDefaultStyle = isDefaultStyle,
-        componentDistinctName = element.name,
     )
 }
 
@@ -292,7 +290,6 @@ internal fun getShowkaseMetadataFromPreview(
             previewParameterName = previewParameterMetadata?.first,
             previewParameterProviderType = previewParameterMetadata?.second,
             componentIndex = index,
-            componentDistinctName =  "${element.name}_$index"
         )
     }
 }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/utils/XProcessingExtensions.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/utils/XProcessingExtensions.kt
@@ -9,8 +9,8 @@ fun XAnnotated.findAnnotationBySimpleName(simpleName: String): XAnnotation? {
     return getAllAnnotations().find { it.name == simpleName }
 }
 
-fun XAnnotated.requireAnnotationBySimpleName(simpleName: String): XAnnotation {
-    return getAllAnnotations().find { it.name == simpleName }
+fun XAnnotated.requireAnnotationBySimpleName(simpleName: String): List<XAnnotation> {
+    return getAllAnnotations().filter { it.name == simpleName }
         ?: throw ShowkaseProcessorException(
             "No annotation named $simpleName found",
             this as? XElement

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
@@ -31,7 +31,12 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
         val autogenClass = TypeSpec.classBuilder(generatedClassName)
 
         showkaseMetadataSet.forEach { showkaseMetadata ->
-            val name = "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}"
+
+            val name = if (showkaseMetadata is ShowkaseMetadata.Component) {
+                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.componentDistinctName}"
+            } else {
+                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}"
+            }
             val methodName = if (showkaseMetadata is ShowkaseMetadata.Component
                 && showkaseMetadata.showkaseStyleName != null
             ) {
@@ -63,9 +68,8 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
         fileBuilder.build().writeTo(environment.filer, mode = XFiler.Mode.Aggregating)
     }
 
-    private fun createShowkaseCodegenMetadata(showkaseMetadata: ShowkaseMetadata) =
-        AnnotationSpec.builder(ShowkaseCodegenMetadata::class)
-            .addMember("showkaseName = %S", showkaseMetadata.showkaseName)
+    private fun createShowkaseCodegenMetadata(showkaseMetadata: ShowkaseMetadata): AnnotationSpec.Builder {
+        val  builder = AnnotationSpec.builder(ShowkaseCodegenMetadata::class)
             .addMember("showkaseGroup = %S", showkaseMetadata.showkaseGroup)
             .addMember("packageName = %S", showkaseMetadata.packageName)
             .addMember("packageSimpleName = %S", showkaseMetadata.packageSimpleName)
@@ -73,6 +77,13 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
             .addMember("insideObject = ${showkaseMetadata.insideObject}")
             .addMember("insideWrapperClass = ${showkaseMetadata.insideWrapperClass}")
             .addMember("showkaseKDoc = %S", showkaseMetadata.showkaseKDoc)
+        if (showkaseMetadata is ShowkaseMetadata.Component && showkaseMetadata.componentDistinctName != null) {
+            builder.addMember("showkaseName = %S", showkaseMetadata.componentDistinctName)
+        } else {
+            builder.addMember("showkaseName = %S", showkaseMetadata.showkaseName)
+        }
+        return builder
+    }
 
     private fun addMetadataTypeSpecificProperties(
         showkaseMetadata: ShowkaseMetadata,

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
-import java.util.*
+import java.util.Locale
 
 internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessingEnv) {
 
@@ -32,8 +32,12 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
 
         showkaseMetadataSet.forEach { showkaseMetadata ->
 
-            val name = if (showkaseMetadata is ShowkaseMetadata.Component) {
-                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.componentDistinctName}"
+            val name = if (
+                showkaseMetadata is ShowkaseMetadata.Component
+                && showkaseMetadata.componentIndex != null
+                && showkaseMetadata.componentIndex > 0
+            ) {
+                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}_${showkaseMetadata.componentIndex}"
             } else {
                 "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}"
             }
@@ -68,8 +72,9 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
         fileBuilder.build().writeTo(environment.filer, mode = XFiler.Mode.Aggregating)
     }
 
-    private fun createShowkaseCodegenMetadata(showkaseMetadata: ShowkaseMetadata): AnnotationSpec.Builder {
-        val  builder = AnnotationSpec.builder(ShowkaseCodegenMetadata::class)
+    private fun createShowkaseCodegenMetadata(showkaseMetadata: ShowkaseMetadata): AnnotationSpec.Builder =
+        AnnotationSpec.builder(ShowkaseCodegenMetadata::class)
+            .addMember("showkaseName = %S", showkaseMetadata.showkaseName)
             .addMember("showkaseGroup = %S", showkaseMetadata.showkaseGroup)
             .addMember("packageName = %S", showkaseMetadata.packageName)
             .addMember("packageSimpleName = %S", showkaseMetadata.packageSimpleName)
@@ -77,13 +82,7 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
             .addMember("insideObject = ${showkaseMetadata.insideObject}")
             .addMember("insideWrapperClass = ${showkaseMetadata.insideWrapperClass}")
             .addMember("showkaseKDoc = %S", showkaseMetadata.showkaseKDoc)
-        if (showkaseMetadata is ShowkaseMetadata.Component && showkaseMetadata.componentDistinctName != null) {
-            builder.addMember("showkaseName = %S", showkaseMetadata.componentDistinctName)
-        } else {
-            builder.addMember("showkaseName = %S", showkaseMetadata.showkaseName)
-        }
-        return builder
-    }
+
 
     private fun addMetadataTypeSpecificProperties(
         showkaseMetadata: ShowkaseMetadata,

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -118,10 +118,15 @@ internal fun CodeBlock.Builder.addShowkaseBrowserComponent(
     showkaseMetadata: ShowkaseMetadata.Component,
     isPreviewParameter: Boolean = false
 ) {
+    val componentName = if (showkaseMetadata.componentIndex != null) {
+        "_${showkaseMetadata.showkaseName}_${showkaseMetadata.componentIndex}"
+    } else {
+        "_${showkaseMetadata.showkaseName}"
+    }
     var componentKey = (showkaseMetadata.packageName +
             "_${showkaseMetadata.enclosingClassName}" +
             "_${showkaseMetadata.showkaseGroup}" +
-            "_${showkaseMetadata.componentDistinctName}" +
+            componentName +
             "_${showkaseMetadata.showkaseStyleName}").replace(
         SPACE_REGEX,
         ""

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -121,7 +121,7 @@ internal fun CodeBlock.Builder.addShowkaseBrowserComponent(
     var componentKey = (showkaseMetadata.packageName +
             "_${showkaseMetadata.enclosingClassName}" +
             "_${showkaseMetadata.showkaseGroup}" +
-            "_${showkaseMetadata.showkaseName}" +
+            "_${showkaseMetadata.componentDistinctName}" +
             "_${showkaseMetadata.showkaseStyleName}").replace(
         SPACE_REGEX,
         ""


### PR DESCRIPTION
This is the next step in supporting Multipreview annotations. Referencing #255 as the first step. 

Here I have added functionality to make a `ShowkaseMetadata` object for each `Preview` annotation. Eg.

```
@Preview(
    name = "small font",
    group = "font scales",
    fontScale = 0.5f
)
@Preview(
    name = "large font",
    group = "font scales",
    fontScale = 1.5f
)
@Composable
fun ComposablePreviewFont() {

}

```

Before, this would only make one component in Showkase. Now it should make one for each preview and place them in their respective group. Here they would both be placed in the group `font scales`

Furthermore, I would advice to review this by commit as I had to update the tests because of some arrangement due to a check in the processor. I placed the test update in 8371ec2efd81e6317c85029e377dca3ae8cd0aee.

I'm leaving this as a draft PR because I'm having some issues with getting this to work with KAPT. 
With KSP, the method `roundEnvironment.getElementsAnnotatedWith(PREVIEW_CLASS_NAME)` returns all the elements for multi stacked preview. However, with KAPT, it does not seem to work the same way. Is there some other function I should use here? Any suggestions are more than welcome 😄 
Added a [slack post](https://kotlinlang.slack.com/archives/C2R77UD35/p1661703541100529) for anyone interested 😄 