### PR TITLE
Stop publishing separate debug and release artifacts for the "showakse" artifact on maven

### DIFF
--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -14,13 +14,6 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
-
-    buildTypes {
-        debug {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-    }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11


### PR DESCRIPTION
Fixes https://github.com/airbnb/Showkase/issues/274

Showkase was publishing separate `debug` and `release` artifacts to maven and this was causing weirdness when consumers had custom build types that weren't `debug` and `release`. Moreover, this wasn't intended to be the case in the first place so I'm attempting to fix this for the future releases. 

<img width="396" alt="Screen Shot 2022-12-20 at 3 03 35 PM" src="https://user-images.githubusercontent.com/4281910/208783039-00113753-65a2-4e0a-9fef-65864ff4cebe.png">
