### PR TITLE
Set update processor test output flag to false

### DIFF
--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/BaseProcessorTest.kt
@@ -16,7 +16,7 @@ import java.io.File
  * Temporarily set this to true to have the test runner update test resource file expected outputs
  * instead of failing tests on mismatch. Use this to easily update expected outputs.
  */
-const val UPDATE_TEST_OUTPUTS = true
+const val UPDATE_TEST_OUTPUTS = false
 
 abstract class BaseProcessorTest {
     @Rule


### PR DESCRIPTION
Noticed this when working on adding processor tests to custom preview annotation feature that this flag was set to true. 

I might be mistaken here, but I think this will then generate the output for all the tests and not actually verify the test themself. Might have been a miss in a feature or something. 

I think also it can be a bit mind bothering for people coming into the project to see that their test output is updating every time they run the test without taking the action to actually set the flag locally themself.

However, if you don't agree, feel free to close this PR.