### PR TITLE
Handle private previews for Custom annotations

### DIFF
--- a/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
@@ -33,3 +33,11 @@ fun CustomRoundedSquareWithText() {
         Text("This is a rounded square!")
     }
 }
+
+@FontPreview
+@Composable
+private fun PrivateCustomRoundedSquareWithText() {
+    Box(Modifier.size(100.dp).clip(RoundedCornerShape(8.dp))) {
+        Text("This is a private rounded square!")
+    }
+}

--- a/showkase-browser-testing/build.gradle
+++ b/showkase-browser-testing/build.gradle
@@ -3,12 +3,16 @@ apply plugin: 'kotlin-android'
 
 if (project.hasProperty('useKsp')) {
     apply plugin: 'com.google.devtools.ksp'
+    ksp {
+        arg("skipPrivatePreviews", "true")
+    }
 } else {
     apply plugin: 'kotlin-kapt'
     kapt {
         correctErrorTypes = true
         arguments {
             arg("multiPreviewType", "com.airbnb.android.submodule.showkasesample.LocalePreview")
+            arg("skipPrivatePreviews", "true")
         }
     }
 }

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -817,8 +817,11 @@ class ShowcaseBrowserTest {
         }
     }
 
+    // We have enabled private preview compiler flag so this test
+    // should test that we can have private methods annotated with custom annotations
+    // and that they will not show in the application.
     @Test
-    fun customAnnotatedPrivateComposablesShouldNotShot() {
+    fun customAnnotatedPrivateComposablesShouldCompileButNotShow() {
 
         composeTestRule.apply {
 

--- a/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
+++ b/showkase-browser-testing/src/androidTest/java/com/airbnb/android/showkase_browser_testing/ShowkaseBrowserTest.kt
@@ -816,4 +816,36 @@ class ShowcaseBrowserTest {
 
         }
     }
+
+    @Test
+    fun customAnnotatedPrivateComposablesShouldNotShot() {
+
+        composeTestRule.apply {
+
+            verifyLandingScreen(
+                components = componentSize,
+                typography = 13,
+                colors = 4,
+            )
+            // Tap on the "Components" row
+            clickRowWithText("Components ($componentSize)")
+
+            waitForIdle()
+
+            onRoot().performTouchInput {
+                swipeUp()
+            }
+
+            waitForIdle()
+
+            val composables = if (BuildConfig.IS_RUNNING_KSP) 3 else 1
+
+            clickRowWithText("LocalePreview ($composables)")
+
+            onNodeWithText("Private Text Composable").assertDoesNotExist()
+
+            waitForIdle()
+
+        }
+    }
 }

--- a/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
+++ b/showkase-browser-testing/src/main/java/com/airbnb/android/showkase_browser_testing/TestComposables.kt
@@ -114,5 +114,11 @@ fun PreviewEnglishText() {
     BasicText(text = "Some text In locale")
 }
 
+@EnglishLocalePreview
+@Composable
+private fun PrivateTextComposable() {
+    BasicText(text = "Private Text Composable")
+}
+
 @ShowkaseRoot
 class MyRootModule: ShowkaseRootModule

--- a/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
+++ b/showkase-processor-testing/src/test/java/com/airbnb/android/showkase_processor_testing/ShowkaseProcessorTest.kt
@@ -611,5 +611,12 @@ class ShowkaseProcessorTest : BaseProcessorTest() {
     fun `top level composable function with showkase and showkaseroot with tags and metadata`() {
         compileInputsAndVerifyOutputs()
     }
+
+    @Test
+    fun `composable function with private custom preview annotation compiles with flag`() {
+        val options = mutableMapOf<String, String>()
+        options["skipPrivatePreviews"] = "true"
+        compileInputsAndVerifyOutputs(options = options)
+    }
 }
 

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_private_custom_preview_annotation_compiles_with_flag/input/Composables.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_private_custom_preview_annotation_compiles_with_flag/input/Composables.kt
@@ -1,0 +1,19 @@
+package com.airbnb.android.showkase_processor_testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+
+@Preview(
+    name = "large Screen",
+    group = "device",
+)
+public annotation class DevicePreviews
+
+public class Composables {
+
+    @DevicePreviews
+    @Composable
+    private fun Component() {
+    }
+}

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_private_custom_preview_annotation_compiles_with_flag/output/ShowkaseMetadata_showkase_com_airbnb_android_showkase_processor_testing_devicepreviews.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_private_custom_preview_annotation_compiles_with_flag/output/ShowkaseMetadata_showkase_com_airbnb_android_showkase_processor_testing_devicepreviews.kt
@@ -1,0 +1,19 @@
+// This is an auto-generated file. Please do not edit/modify this file.
+package com.airbnb.android.showkase
+
+import com.airbnb.android.showkase.`annotation`.ShowkaseMultiPreviewCodegenMetadata
+import kotlin.Unit
+
+public class ShowkaseMetadata_showkase_com_airbnb_android_showkase_processor_testing_devicepreviews
+    {
+  @ShowkaseMultiPreviewCodegenMetadata(
+    previewName = "large Screen",
+    previewGroup = "device",
+    supportTypeQualifiedName = "com.airbnb.android.showkase_processor_testing.DevicePreviews",
+    showkaseWidth = -1,
+    showkaseHeight = -1,
+    packageName = "com.airbnb.android.showkase_processor_testing",
+  )
+  public fun Preview_0(): Unit {
+  }
+}


### PR DESCRIPTION
The validation was not quite handled for the custom annotation processing steps and it had not passed the flag since it had a default argument. This caused the validation to hit the step to indicate to add the private preview flag for the user even though they had already added that.

resolves #312 

This was totally my mistake, I should have handled this in my initial PR. Sorry about that