### PR TITLE
De-dupe with the fully qualified function name

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -275,13 +275,13 @@ class ShowkaseProcessor @JvmOverloads constructor(
     }
 
     private fun Collection<ShowkaseMetadata.Component>.dedupeAndSort() = this.distinctBy {
-            // It's possible that a composable annotation is annotated with both Preview &
-            // ShowkaseComposable(especially if we add more functionality to Showkase and they diverge
-            // in the customizations that they offer). In that scenario, its important to dedupe the
-            // composables as they will be processed across both the rounds. We first ensure that
-            // only distict method's are passed onto the next round. We do this by deduping on
-            // the combination of packageName, the wrapper class when available(otherwise it
-            // will be null) & the methodName.
+        // It's possible that a composable annotation is annotated with both Preview &
+        // ShowkaseComposable(especially if we add more functionality to Showkase and they diverge
+        // in the customizations that they offer). In that scenario, its important to dedupe the
+        // composables as they will be processed across both the rounds. We first ensure that
+        // only distict method's are passed onto the next round. We do this by deduping on
+        // the combination of packageName, the wrapper class when available(otherwise it
+        // will be null) & the methodName.
         if (it.componentIndex != null) {
             "${it.packageName}_${it.enclosingClassName}_${it.elementName}_${it.componentIndex}"
         } else {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -275,13 +275,13 @@ class ShowkaseProcessor @JvmOverloads constructor(
     }
 
     private fun Collection<ShowkaseMetadata.Component>.dedupeAndSort() = this.distinctBy {
-        // It's possible that a composable annotation is annotated with both Preview & 
-        // ShowkaseComposable(especially if we add more functionality to Showkase and they diverge
-        // in the customizations that they offer). In that scenario, its important to dedupe the
-        // composables as they will be processed across both the rounds. We first ensure that
-        // only distict method's are passed onto the next round. We do this by deduping on 
-        // the combination of packageName, the wrapper class when available(otherwise it 
-        // will be null) & the methodName.
+            // It's possible that a composable annotation is annotated with both Preview &
+            // ShowkaseComposable(especially if we add more functionality to Showkase and they diverge
+            // in the customizations that they offer). In that scenario, its important to dedupe the
+            // composables as they will be processed across both the rounds. We first ensure that
+            // only distict method's are passed onto the next round. We do this by deduping on
+            // the combination of packageName, the wrapper class when available(otherwise it
+            // will be null) & the methodName.
         if (it.componentIndex != null) {
             "${it.packageName}_${it.enclosingClassName}_${it.elementName}_${it.componentIndex}"
         } else {
@@ -290,16 +290,18 @@ class ShowkaseProcessor @JvmOverloads constructor(
         }
     }
         .distinctBy {
-            // We also ensure that the component groupName and the component name are unique so 
-            // that they don't show up twice in the browser app.
+            // We also ensure that the component groupName and the component name are unique so
+            // that they don't show up twice in the browser app. This also de-duplicates based
+            // on the fully qualified function name to support categorization with additional
+            // fields (e.g. tags, extraMetadata, etc) on custom browsers.
             if (it.componentIndex != null) {
-                "${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}_${it.componentIndex}"
+                "${it.fqPrefix}_${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}_${it.componentIndex}"
             } else {
-                "${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}"
+                "${it.fqPrefix}_${it.showkaseName}_${it.showkaseGroup}_${it.showkaseStyleName}"
             }
         }
         .sortedBy {
-            "${it.packageName}_${it.enclosingClassName}_${it.elementName}"
+            it.fqPrefix
         }
 
     private fun processColorAnnotation(roundEnvironment: XRoundEnv): Set<ShowkaseMetadata> {

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -42,6 +42,10 @@ internal sealed class ShowkaseMetadata {
     abstract val insideWrapperClass: Boolean
     abstract val insideObject: Boolean
 
+    /** A fully qualified prefix for use when de-duplicating components. **/
+    val fqPrefix: String
+        get() = "${packageName}_${enclosingClassName}_$elementName"
+
     data class Component(
         override val element: XElement,
         override val packageName: String,

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseCodegenMetadataWriter.kt
@@ -36,9 +36,9 @@ internal class ShowkaseCodegenMetadataWriter(private val environment: XProcessin
                 && showkaseMetadata.componentIndex != null
                 && showkaseMetadata.componentIndex > 0
             ) {
-                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}_${showkaseMetadata.componentIndex}"
+                "${showkaseMetadata.fqPrefix}_${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}_${showkaseMetadata.componentIndex}"
             } else {
-                "${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}"
+                "${showkaseMetadata.fqPrefix}_${showkaseMetadata.showkaseGroup}_${showkaseMetadata.showkaseName}"
             }
             val methodName = if (showkaseMetadata is ShowkaseMetadata.Component
                 && showkaseMetadata.showkaseStyleName != null

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -107,7 +107,7 @@ internal fun CodeBlock.Builder.addShowkaseBrowserComponent(
     } else {
         "_${showkaseMetadata.showkaseName}"
     }
-    var componentKey = (showkaseMetadata.packageName +
+    var componentKey = (showkaseMetadata.fqPrefix +
             "_${showkaseMetadata.enclosingClassName}" +
             "_${showkaseMetadata.showkaseGroup}" +
             componentName +
@@ -323,10 +323,10 @@ internal fun generatePropertyNameFromMetadata(
             val name =
                 if (metadata.componentIndex != null && metadata.componentIndex > 0
                 ) {
-                    "${metadata.packageName}_${metadata.showkaseGroup}_" +
+                    "${metadata.fqPrefix}_${metadata.showkaseGroup}_" +
                             "${metadata.showkaseName}_${metadata.componentIndex}"
                 } else {
-                    "${metadata.packageName}_${metadata.showkaseGroup}_${metadata.showkaseName}"
+                    "${metadata.fqPrefix}_${metadata.showkaseGroup}_${metadata.showkaseName}"
                 }
             val propertyName = if (metadata.showkaseStyleName != null) {
                 "${name}_${metadata.showkaseStyleName}"
@@ -336,7 +336,7 @@ internal fun generatePropertyNameFromMetadata(
             propertyName
         }
         else -> {
-            "${metadata.packageName}_${metadata.showkaseGroup}_${metadata.showkaseName}"
+            "${metadata.fqPrefix}_${metadata.showkaseGroup}_${metadata.showkaseName}"
                 .filter { it.isLetterOrDigit() }
         }
     }


### PR DESCRIPTION
This adds the fully qualified name (package + class name + function name) to the de-duplication strategy to support showkase components with the same group/component name/style name. This is useful when creating custom browsers where additional categorization is made via the new `tags` or `extraMetadata` fields that were added with https://github.com/airbnb/Showkase/pull/309.