### PR TITLE
Fix `width` incorrectly passed to `showkaseHeightDp` param in `ShowkaseMetadata`.

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -353,7 +353,7 @@ internal fun getShowkaseMetadataFromCustomAnnotation(
             showkaseName = showkaseName,
             showkaseGroup = showkaseGroup,
             showkaseWidthDp = if (width == -1) null else width,
-            showkaseHeightDp = if (height == -1) null else width,
+            showkaseHeightDp = if (height == -1) null else height,
             insideWrapperClass = commonMetadata.showkaseFunctionType == ShowkaseFunctionType.INSIDE_CLASS,
             insideObject = commonMetadata.showkaseFunctionType.insideObject(),
             element = element,


### PR DESCRIPTION
Most likely a typo I suppose.