### PR TITLE
Remove the `Deprecation` warning on generated module files when building

### DIFF
--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_paparazzi_screenshot_test_for_all_UI_elements/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_paparazzi_screenshot_test_for_all_UI_elements/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -21,8 +21,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
  */
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
-      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen").newInstance() as
-          ShowkaseProvider
+      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_generates_screenshot_test_for_all_UI_elements/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/class_with_@ScreenshotTest_only_generates_screenshot_test_for_only_non_preview_parameter_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_class_with_showkasecolor_annotation_and_showkaseroot_with_no_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/color_property_inside_object_with_showkasecolor_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_class_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_companion_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_inside_object_with_showkase_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_that_has_default_parameters_compiles_ok/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_function_with_kdoc_inside_object_with_showkase_annotation_and_showkaseroot_generates_2_files/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_previews_with_multiple_parameter_providers_should_indent_properly/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/composable_previews_with_multiple_parameter_providers_should_indent_properly/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/object_function_with_preview_annotation_and_preview_parameter_and_showkaseroot_and_long_parameter_provider_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing_my_very_long_name.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing_my_very_long_name.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_class_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/textstyle_property_inside_object_with_showkasetypography_annotation_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_paparazzi_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_paparazzi_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -21,8 +21,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
  */
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
-      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen").newInstance() as
-          ShowkaseProvider
+      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_and_composable_function_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_color_property_with_showkasecolor_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_Paparazzi_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_Paparazzi_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -21,8 +21,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
  */
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
-      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen").newInstance() as
-          ShowkaseProvider
+      val showkaseComponentProvider = Class.forName(".TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_with_width_and_height/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_preview_and_showkaseroot_with_width_and_height/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_with_tags_and_metadata/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_with_tags_and_metadata/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_with_width_and_height/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_composable_function_with_showkase_and_showkaseroot_with_width_and_height/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_preview_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_and_no_name_or_group/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_and_class_with_@ScreenshotTest_generates_screenshot_test_for_composable/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_and_composable_function_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_generates_1_file/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/top_level_textstyle_property_with_showkasetypography_and_showkaseroot_with_no_name/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
+++ b/showkase-processor-testing/src/test/resources/ShowkaseProcessorTest/wrapped_function_with_showkase_composable_and_preview_parameter_and_showkaseroot_/output/TestShowkaseRootShowkaseExtensionFunctionsCodegen.kt
@@ -25,8 +25,9 @@ public fun Showkase.getBrowserIntent(context: Context): Intent {
 public fun Showkase.getMetadata(): ShowkaseElementsMetadata {
     try {
       val showkaseComponentProvider =
-          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen").newInstance()
-          as ShowkaseProvider
+          Class.forName("com.airbnb.android.showkase_processor_testing.TestShowkaseRootCodegen")
+          	.getDeclaredConstructor()
+          	.newInstance() as ShowkaseProvider
       return showkaseComponentProvider.metadata()
     } catch(exception: ClassNotFoundException) {
       error("The class wasn't generated correctly. Make sure that you have setup Showkase correctly by following the steps here - https://github.com/airbnb/Showkase#Installation.")

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseExtensionFunctionsWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseExtensionFunctionsWriter.kt
@@ -94,7 +94,9 @@ internal class ShowkaseExtensionFunctionsWriter(
                 .addStatement("try {")
                 .indent()
                 .addStatement(
-                    "val showkaseComponentProvider = Class.forName(\"${classKey}Codegen\").getDeclaredConstructor().newInstance() as %T",
+                    "val showkaseComponentProvider = Class.forName(\"${classKey}Codegen\")\n\t" +
+                            ".getDeclaredConstructor()\n\t" +
+                            ".newInstance() as %T",
                     SHOWKASE_PROVIDER_CLASS_NAME
                 )
                 .addStatement("return %L.metadata()", "showkaseComponentProvider")

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseExtensionFunctionsWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseExtensionFunctionsWriter.kt
@@ -94,7 +94,7 @@ internal class ShowkaseExtensionFunctionsWriter(
                 .addStatement("try {")
                 .indent()
                 .addStatement(
-                    "val showkaseComponentProvider = Class.forName(\"${classKey}Codegen\").newInstance() as %T",
+                    "val showkaseComponentProvider = Class.forName(\"${classKey}Codegen\").getDeclaredConstructor().newInstance() as %T",
                     SHOWKASE_PROVIDER_CLASS_NAME
                 )
                 .addStatement("return %L.metadata()", "showkaseComponentProvider")
@@ -125,7 +125,7 @@ internal class ShowkaseExtensionFunctionsWriter(
             ClassName(CONTEXT_PACKAGE_NAME, "Intent")
         private val SHOWKASE_BROWSER_ACTIVITY_CLASS_NAME =
             ClassName("com.airbnb.android.showkase.ui", "ShowkaseBrowserActivity")
-        private val SHOWKASE_ELEMENTS_METADATA_CLASS_NAME = 
+        private val SHOWKASE_ELEMENTS_METADATA_CLASS_NAME =
             ClassName(SHOWKASE_MODELS_PACKAGE_NAME, "ShowkaseElementsMetadata")
         internal val SHOWKASE_OBJECT_CLASS_NAME =
             ClassName(SHOWKASE_MODELS_PACKAGE_NAME, "Showkase")


### PR DESCRIPTION
It just uses the API proposed by the deprecation warning on API 34.

Fixes https://github.com/airbnb/Showkase/issues/335.