### PR TITLE
Embed proguard rule for generated provider class

### DIFF
--- a/showkase/consumer-rules.pro
+++ b/showkase/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep public class * extends com.airbnb.android.showkase.models.ShowkaseProvider


### PR DESCRIPTION
## Summary

Embed proguard rules for Codegen class so that minifyEnabled applications do not need additional rules.

Since the Codegen class extends the ShowkaseProvider class, additional rules are unnecessary for each application by providing rules for types that extend the ShowkaseProvider class.

consumerProguardRules is already specified in the project, so I added to it. 
https://github.com/airbnb/Showkase/blob/4a09e3ff1d3ef71c6b151b5c7deefc82529691c0/showkase/build.gradle#L15

refs. https://github.com/airbnb/Showkase/issues/199, https://github.com/airbnb/Showkase/issues/244

## Context

Currently, we need to add extra proguard rules if we set minifyEnabled as true

```kotlin
@ShowkaseRootModule
class SampleShowkaseRootModule : ShowkaseRootModule

// Showkase generated class
public class SampleShowkaseRootModuleCodegen : ShowkaseProvider
```

```shell
# application proguard rules
-keep class **.SampleShowkaseRootModuleCodegen { }
```


