### PR TITLE
Specify available macOS version for CI workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,7 +64,7 @@ jobs:
           retention-days: 1
 
   ui-testing:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       matrix:
         api-level: [ 26, 29 ]


### PR DESCRIPTION
macos-10.15 for GitHub Actions is already removed, so specified available macOS version as GitHub Actions runner.

See more: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

Available GitHub Runners: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

