### PR TITLE
Reverts #341 and instead adds that information in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ class MyRootModule: ShowkaseRootModule
 startActivity(Showkase.getBrowserIntent(context))
 ```
 
+Most users of Showkase will use it in their debug builds. However, if you have a use case where you would
+like to use Showkase in a release build (or a build that has minification enabled), you will need to add
+the following line to your proguard rules
+
+```
+-keep public class * extends com.airbnb.android.showkase.models.ShowkaseProvider
+```
+
 ## Documentation
 
 ##### 1. @ShowkaseComposable

--- a/showkase/consumer-rules.pro
+++ b/showkase/consumer-rules.pro
@@ -1,1 +1,1 @@
--keep public class * extends com.airbnb.android.showkase.models.ShowkaseProvider
+


### PR DESCRIPTION
As I was publishing the latest release and going through each change that made it's way into the release, I looked at this PR again - https://github.com/airbnb/Showkase/pull/341. 

While this is useful for teams that are using Showkase with a release build, it's far more common to use Showkase as a "debug only" component browser. I think this change will actually cause all the previews to be retained since we are explicitly retaining the file that holds a reference to them. As a result, I'm reverting that PR and instead adding this information in the README in cases where you need to use Showkase in builds that have minification enabled. 

