### PR TITLE
Stop exporting ShowkaseBrowserActivity

### DIFF
--- a/showkase/src/main/AndroidManifest.xml
+++ b/showkase/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
             android:name="com.airbnb.android.showkase.ui.ShowkaseBrowserActivity"
             android:configChanges="colorMode|density|fontScale|keyboard|keyboardHidden|layoutDirection|locale|mcc|mnc|navigation|orientation|screenLayout|screenSize|smallestScreenSize|touchscreen|uiMode"
             android:label="ShowkaseBrowserActivity"
-            android:theme="@style/Theme.App.NoActionBar"
-            android:exported="true">
+            android:theme="@style/Theme.App.NoActionBar">
         </activity>
     </application>
 </manifest>


### PR DESCRIPTION
Fixes https://github.com/airbnb/Showkase/issues/347

This was done in this PR (https://github.com/airbnb/Showkase/commit/469e14de06227d32974d2b3fa67646ff53013e17#diff-fdcbc654693654c9611addef6b4e7ef93e1ae16aa06522b1c02d9786a3d5ecb5R10) in order to [make it compatible with Android 12](https://developer.android.com/about/versions/12/behavior-changes-12#exported). However, it's only needed for launcher activities (or activities with an intent filter), which `ShowkaseBrowserActivity` isn't. So it's safe to remove this line from our codebase. 