### PR TITLE
Fix missing category of originating elements

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserPropertyWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserPropertyWriter.kt
@@ -238,7 +238,7 @@ internal data class ShowkaseBrowserProperties(
             colors.isEmpty() &&
             typography.isEmpty()
 
-    fun zip() = componentsWithPreviewParameters + componentsWithPreviewParameters + colors + typography
+    fun zip() = componentsWithPreviewParameters + componentsWithoutPreviewParameters + colors + typography
 
     operator fun plus(other: ShowkaseBrowserProperties): ShowkaseBrowserProperties {
         return ShowkaseBrowserProperties(


### PR DESCRIPTION
Eagled eyed @elihart spotted that we were not adding the originating elements for previews that were without the `PreviewParameter`. This is the far more common case and could potentially be causing build issues when there were changes in the element. It primarily has implications on the ability to do proper incremental compilation