### PR TITLE
Generate files based on source file name instead of property name

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/ShowkaseProcessor.kt
@@ -52,7 +52,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
     private val logger = ShowkaseExceptionLogger()
     private val showkaseValidator by lazy { ShowkaseValidator(environment) }
 
-    override fun getSupportedAnnotationTypes(): MutableSet<String>  {
+    override fun getSupportedAnnotationTypes(): MutableSet<String> {
         val supportedAnnotations = mutableSetOf(
             ShowkaseComposable::class.java.name,
             PREVIEW_CLASS_NAME,
@@ -78,6 +78,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
             ?.toSet()?.let { set.addAll(it) }
         return set
     }
+
     override fun getSupportedOptions() = mutableSetOf("skipPrivatePreviews", "multiPreviewType")
 
     override fun process(environment: XProcessingEnv, round: XRoundEnv) {
@@ -100,7 +101,8 @@ class ShowkaseProcessor @JvmOverloads constructor(
         val showkaseComposablesMetadata = processShowkaseAnnotation(roundEnvironment)
         val previewComposablesMetadata = processPreviewAnnotation(roundEnvironment)
 
-        val customPreviewFromClassPathMetadata = processCustomAnnotationFromClasspath(roundEnvironment)
+        val customPreviewFromClassPathMetadata =
+            processCustomAnnotationFromClasspath(roundEnvironment)
         return (showkaseComposablesMetadata + previewComposablesMetadata + customPreviewFromClassPathMetadata)
             .dedupeAndSort()
             .toSet()
@@ -212,6 +214,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     null -> {
                         null
                     }
+
                     else -> {
                         val codeGenAnnotation = ShowkaseMultiPreviewCodegenMetadata(
                             previewName = annotation.value.previewName,
@@ -266,11 +269,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
             generateShowkaseCodegenFunctions(aggregateMetadataList)
         }
         ShowkaseBrowserPropertyWriter(environment).apply {
-            return generateMetadataPropertyFiles(
-                componentMetadata = componentMetadata,
-                colorMetadata = colorMetadata,
-                typographyMetadata = typographyMetadata,
-            )
+            return generateMetadataPropertyFiles(aggregateMetadataList)
         }
     }
 
@@ -519,7 +518,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
             element = element,
             propertyName = props.generatedPropertyName,
             propertyPackage = props.packageName,
-            type = when(type) {
+            type = when (type) {
                 ShowkaseMetadataType.COLOR -> ShowkaseGeneratedMetadataType.COLOR
                 ShowkaseMetadataType.TYPOGRAPHY -> ShowkaseGeneratedMetadataType.TYPOGRAPHY
                 ShowkaseMetadataType.COMPONENT -> if (previewParameterClassType != null) {
@@ -535,6 +534,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
             extraMetadata = props.extraMetadata.toList()
         )
     }
+
     private fun getShowkaseRootCodegenOnClassPath(
         specifiedRootClassTypeElement: XTypeElement
     ): ShowkaseRootCodegen? {
@@ -580,7 +580,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
         rootModulePackageName: String,
         testClassName: String,
     ) {
-        when(screenshotTestType) {
+        when (screenshotTestType) {
             // We only handle composables without preview parameter for screenshots. This is because
             // there's no way to get information about how many previews are dynamically generated using
             // preview parameter as it happens on run time and our codegen doesn't get enough information
@@ -599,6 +599,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
                     )
                 }
             }
+
             ScreenshotTestType.PAPARAZZI_SHOWKASE -> {
                 PaparazziShowkaseScreenshotTestWriter(environment).apply {
                     generateScreenshotTests(
@@ -616,6 +617,7 @@ class ShowkaseProcessor @JvmOverloads constructor(
         val colorsSize: Int,
         val typographySize: Int,
     )
+
     companion object {
         internal const val COMPOSABLE_SIMPLE_NAME = "Composable"
         internal const val PREVIEW_CLASS_NAME = "androidx.compose.ui.tooling.preview.Preview"

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserPropertyWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserPropertyWriter.kt
@@ -17,101 +17,107 @@ import com.squareup.kotlinpoet.asTypeName
 class ShowkaseBrowserPropertyWriter(private val environment: XProcessingEnv) {
     @Suppress("LongMethod")
     internal fun generateMetadataPropertyFiles(
-        componentMetadata: Set<ShowkaseMetadata.Component>,
-        colorMetadata: Set<ShowkaseMetadata>,
-        typographyMetadata: Set<ShowkaseMetadata>,
+        allMetadata: Set<ShowkaseMetadata>,
     ): ShowkaseBrowserProperties {
-        val (showkaseMetadataWithParameterList, showkaseMetadataWithoutParameterList) =
-            componentMetadata
-                .partition {
-                    it.previewParameterProviderType != null
-                }
 
-        // Generate top level property file for components without preview parameter provider
-        val withoutParameterPropertyNames =
-            showkaseMetadataWithoutParameterList.mapIndexed { index, showkaseMetadata ->
-                val propertyName = generatePropertyNameFromMetadata(showkaseMetadata)
-                val fileBuilder = getFileBuilder(showkaseMetadata.packageName, propertyName)
-                val property =
-                    getPropertyForComponentWithoutParameter(propertyName, showkaseMetadata)
+        val withoutParameterPropertyNames = mutableListOf<ShowkaseGeneratedMetadata>()
+        val withParameterPropertyNames = mutableListOf<ShowkaseGeneratedMetadata>()
+        val colorPropertyNames = mutableListOf<ShowkaseGeneratedMetadata>()
+        val typographyPropertyNames = mutableListOf<ShowkaseGeneratedMetadata>()
 
-                fileBuilder.addPropertyAndGenerateFile(property)
-                return@mapIndexed ShowkaseGeneratedMetadata(
-                    element = showkaseMetadata.element,
-                    propertyName = propertyName,
-                    propertyPackage = showkaseMetadata.packageName,
-                    type = ShowkaseGeneratedMetadataType.COMPONENTS_WITHOUT_PARAMETER,
-                    group = showkaseMetadata.showkaseGroup,
-                    name = showkaseMetadata.showkaseName,
-                    isDefaultStyle = showkaseMetadata.isDefaultStyle,
-                    tags = showkaseMetadata.tags,
-                    extraMetadata = showkaseMetadata.extraMetadata,
-                )
-            }
-
-        // Generate top level property file for components with preview parameter provider
-        val withParameterPropertyNames =
-            showkaseMetadataWithParameterList.mapIndexed { index, showkaseMetadata ->
-                val propertyName = generatePropertyNameFromMetadata(showkaseMetadata)
-                val fileBuilder = getFileBuilder(showkaseMetadata.packageName, propertyName)
-                val property = getPropertyForComponentWithParameter(propertyName, showkaseMetadata)
-
-                fileBuilder.addPropertyAndGenerateFile(property)
-
-                return@mapIndexed ShowkaseGeneratedMetadata(
-                    element = showkaseMetadata.element,
-                    propertyName = propertyName,
-                    propertyPackage = showkaseMetadata.packageName,
-                    type = ShowkaseGeneratedMetadataType.COMPONENTS_WITH_PARAMETER,
-                    group = showkaseMetadata.showkaseGroup,
-                    name = showkaseMetadata.showkaseName,
-                    isDefaultStyle = showkaseMetadata.isDefaultStyle,
-                    tags = showkaseMetadata.tags,
-                    extraMetadata = showkaseMetadata.extraMetadata,
-                )
-            }
-
-        // Generate top level property file for colors
-        val colorPropertyNames = colorMetadata.mapIndexed { index, color ->
-            val propertyName = generatePropertyNameFromMetadata(color)
-            val fileBuilder = getFileBuilder(color.packageName, propertyName)
-            val colorProperty = getPropertyForMetadata(
-                propertyName,
-                color,
-                ShowkaseBrowserWriter.SHOWKASE_BROWSER_COLOR_CLASS_NAME
-            ) { addShowkaseBrowserColor(color) }
-
-            fileBuilder.addPropertyAndGenerateFile(colorProperty)
-            return@mapIndexed ShowkaseGeneratedMetadata(
-                element = color.element,
-                propertyName = propertyName,
-                propertyPackage = color.packageName,
-                type = ShowkaseGeneratedMetadataType.COLOR,
-                group = color.showkaseGroup,
-                name = color.showkaseName,
+        for ((file, metadataList) in allMetadata.groupBy { it.element.closestMemberContainer }) {
+            val fileBuilder = getFileBuilder(
+                file.asClassName().packageName,
+                "Showkase_${file.name}"
             )
-        }
+            for (metadata in metadataList) {
+                when (metadata) {
+                    is ShowkaseMetadata.Component -> {
+                        val propertyName = generatePropertyNameFromMetadata(metadata)
+                        if (metadata.previewParameterProviderType != null) {
+                            val property =
+                                getPropertyForComponentWithParameter(propertyName, metadata)
+                            fileBuilder.addProperty(property)
+                            withParameterPropertyNames.add(
+                                ShowkaseGeneratedMetadata(
+                                    element = metadata.element,
+                                    propertyName = propertyName,
+                                    propertyPackage = metadata.packageName,
+                                    type = ShowkaseGeneratedMetadataType.COMPONENTS_WITH_PARAMETER,
+                                    group = metadata.showkaseGroup,
+                                    name = metadata.showkaseName,
+                                    isDefaultStyle = metadata.isDefaultStyle,
+                                    tags = metadata.tags,
+                                    extraMetadata = metadata.extraMetadata,
+                                )
+                            )
+                        } else {
+                            val property =
+                                getPropertyForComponentWithoutParameter(
+                                    propertyName,
+                                    metadata
+                                )
+                            fileBuilder.addProperty(property)
+                            withoutParameterPropertyNames.add(
+                                ShowkaseGeneratedMetadata(
+                                    element = metadata.element,
+                                    propertyName = propertyName,
+                                    propertyPackage = metadata.packageName,
+                                    type = ShowkaseGeneratedMetadataType.COMPONENTS_WITHOUT_PARAMETER,
+                                    group = metadata.showkaseGroup,
+                                    name = metadata.showkaseName,
+                                    isDefaultStyle = metadata.isDefaultStyle,
+                                    tags = metadata.tags,
+                                    extraMetadata = metadata.extraMetadata,
+                                )
+                            )
+                        }
+                    }
 
-        // Generate top level property file for typography
-        val typographyPropertyNames =
-            typographyMetadata.mapIndexed { index, typography ->
-                val propertyName = generatePropertyNameFromMetadata(typography)
-                val fileBuilder = getFileBuilder(typography.packageName, propertyName)
-                val typographyProperty = getPropertyForMetadata(
-                    propertyName,
-                    typography,
-                    ShowkaseBrowserWriter.SHOWKASE_BROWSER_TYPOGRAPHY_CLASS_NAME
-                ) { addShowkaseBrowserTypography(typography) }
-                fileBuilder.addPropertyAndGenerateFile(typographyProperty)
-                return@mapIndexed ShowkaseGeneratedMetadata(
-                    element = typography.element,
-                    propertyName = propertyName,
-                    propertyPackage = typography.packageName,
-                    type = ShowkaseGeneratedMetadataType.COLOR,
-                    group = typography.showkaseGroup,
-                    name = typography.showkaseName,
-                )
+                    is ShowkaseMetadata.Color -> {
+                        val propertyName = generatePropertyNameFromMetadata(metadata)
+                        val colorProperty = getPropertyForMetadata(
+                            propertyName,
+                            metadata,
+                            ShowkaseBrowserWriter.SHOWKASE_BROWSER_COLOR_CLASS_NAME
+                        ) { addShowkaseBrowserColor(metadata) }
+
+                        fileBuilder.addProperty(colorProperty)
+                        colorPropertyNames.add(
+                            ShowkaseGeneratedMetadata(
+                                element = metadata.element,
+                                propertyName = propertyName,
+                                propertyPackage = metadata.packageName,
+                                type = ShowkaseGeneratedMetadataType.COLOR,
+                                group = metadata.showkaseGroup,
+                                name = metadata.showkaseName,
+                            )
+                        )
+                    }
+
+                    is ShowkaseMetadata.Typography -> {
+                        val propertyName = generatePropertyNameFromMetadata(metadata)
+                        val typographyProperty = getPropertyForMetadata(
+                            propertyName,
+                            metadata,
+                            ShowkaseBrowserWriter.SHOWKASE_BROWSER_TYPOGRAPHY_CLASS_NAME
+                        ) { addShowkaseBrowserTypography(metadata) }
+                        fileBuilder.addProperty(typographyProperty)
+                        typographyPropertyNames.add(
+                            ShowkaseGeneratedMetadata(
+                                element = metadata.element,
+                                propertyName = propertyName,
+                                propertyPackage = metadata.packageName,
+                                type = ShowkaseGeneratedMetadataType.COLOR,
+                                group = metadata.showkaseGroup,
+                                name = metadata.showkaseName,
+                            )
+                        )
+                    }
+                }
             }
+            fileBuilder.build().writeTo(environment.filer, XFiler.Mode.Isolating)
+        }
 
         return ShowkaseBrowserProperties(
             componentsWithoutPreviewParameters = withoutParameterPropertyNames,
@@ -182,14 +188,6 @@ class ShowkaseBrowserPropertyWriter(private val environment: XProcessingEnv) {
             .build()
     }
 
-    private fun FileSpec.Builder.addPropertyAndGenerateFile(
-        propertySpec: PropertySpec,
-    ) {
-        addProperty(propertySpec)
-        build()
-            .writeTo(environment.filer, mode = XFiler.Mode.Isolating)
-    }
-
     private fun CodeBlock.Builder.addPreviewProviderComponent(withParameterMetadata: ShowkaseMetadata.Component) {
         addLineBreak()
         add(
@@ -238,7 +236,8 @@ internal data class ShowkaseBrowserProperties(
             colors.isEmpty() &&
             typography.isEmpty()
 
-    fun zip() = componentsWithPreviewParameters + componentsWithoutPreviewParameters + colors + typography
+    fun zip() =
+        componentsWithPreviewParameters + componentsWithoutPreviewParameters + colors + typography
 
     operator fun plus(other: ShowkaseBrowserProperties): ShowkaseBrowserProperties {
         return ShowkaseBrowserProperties(


### PR DESCRIPTION
This reduces the length of the filename because a disambiguated property name can be quite long. Looking at the files gerenated in the sample app, before this change the longest is 161 chars, after it's 102.

Partially addresses #340