### PR TITLE
Fix error that prevented incremental compilation for previews that leverage custom annotations

### DIFF
--- a/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.android.submodule.showkasesample.FontPreview
 
-@Preview(name = "Shapessss 200 by 200", group = "Shapes", widthDp = 100, heightDp = 100)
+@Preview(name = "Shape 100 by 100", group = "Shapes", widthDp = 100, heightDp = 100)
 @Preview(name = "Shape 150 by 150", group = "Shapes", widthDp = 150, heightDp = 150)
 annotation class CustomShape
 

--- a/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
+++ b/sample/src/main/java/com/airbnb/android/showkasesample/CustomShape.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.airbnb.android.submodule.showkasesample.FontPreview
 
-@Preview(name = "Shape 100 by 100", group = "Shapes", widthDp = 100, heightDp = 100)
+@Preview(name = "Shapessss 200 by 200", group = "Shapes", widthDp = 100, heightDp = 100)
 @Preview(name = "Shape 150 by 150", group = "Shapes", widthDp = 150, heightDp = 150)
 annotation class CustomShape
 

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/ShowkaseBrowserWriter.kt
@@ -3,6 +3,7 @@ package com.airbnb.android.showkase.processor.writer
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XFiler
 import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.addOriginatingElement
 import androidx.room.compiler.processing.get
 import androidx.room.compiler.processing.isTypeElement
 import androidx.room.compiler.processing.writeTo
@@ -192,7 +193,10 @@ internal class ShowkaseBrowserWriter(private val environment: XProcessingEnv) {
         }
 
         fileBuilder.addType(
-            TypeSpec.classBuilder(generatedClassName).addFunctions(functions).build()
+            with(TypeSpec.classBuilder(generatedClassName).addFunctions(functions)) {
+                addOriginatingElement(element)
+                build()
+            }
         ).addFileComment("This is an auto-generated file. Please do not edit/modify this file.")
         fileBuilder.build().writeTo(environment.filer, mode = XFiler.Mode.Aggregating)
     }


### PR DESCRIPTION
Noticed this in the build and putting up a fix to prevent this error from happening. This was specifically happening if you used custom annotations for annotating your previews

<img width="1046" alt="Screenshot 2024-05-20 at 10 27 51 PM" src="https://github.com/airbnb/Showkase/assets/4281910/d263f4a9-163c-4f7d-b384-56e2751cef0e">

@airbnb/showkase-maintainers 
