### PR TITLE
Upgraded Kotlin/KSP/Compose versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Showkase
-![Showkase Version](https://img.shields.io/badge/Showkase-1.0.2-brightgreen) ![Compatible with Compose](https://img.shields.io/badge/Compatible%20with%20Compose-1.4.2-brightgreen)
+![Showkase Version](https://img.shields.io/badge/Showkase-1.0.2-brightgreen) ![Compatible with Compose](https://img.shields.io/badge/Compatible%20with%20Compose-1.5.13-brightgreen)
 
 Showkase is an annotation-processor based Android library that helps you organize, discover, search 
 and visualize [Jetpack Compose](https://developer.android.com/jetpack/compose) UI elements. With 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
             'junitImplementation'    : '1.1.2',
             'kotlin'                 : '1.9.23',
             'kotlinCompilerVersion'  : '1.9.23',
-            'kotlinCompileTesting'   : '0.4.0',
+            'kotlinCompileTesting'   : '0.4.1',
             'kotlinPoet'             : '1.12.0',
             'kotlinXMetadata'        : '0.6.0',
             'ksp'                    : "$KSP_VERSION",

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.KSP_VERSION = '1.9.20-1.0.14'
+    ext.KSP_VERSION = '1.9.23-1.0.20'
     ext.versions = [
             'androidXTestCore'       : '1.4.0',
             'androidXTestRules'      : '1.4.0',
             'assertJ'                : '3.16.1',
             'compose'                : '1.6.7',
-            'composeCompiler'        : '1.5.5',
+            'composeCompiler'        : '1.5.13',
             'composeActivity'        : '1.9.0',
             'composeConstraintLayout': '1.0.1',
             'composeNavigation'      : '2.5.1',
@@ -15,8 +15,8 @@ buildscript {
             'gradle'                 : '8.1.1',
             'junit'                  : '4.13.2',
             'junitImplementation'    : '1.1.2',
-            'kotlin'                 : '1.9.20',
-            'kotlinCompilerVersion'  : '1.9.20',
+            'kotlin'                 : '1.9.23',
+            'kotlinCompilerVersion'  : '1.9.23',
             'kotlinCompileTesting'   : '0.4.0',
             'kotlinPoet'             : '1.12.0',
             'kotlinXMetadata'        : '0.6.0',

--- a/showkase-processor-testing/build.gradle
+++ b/showkase-processor-testing/build.gradle
@@ -85,14 +85,7 @@ dependencies {
     testImplementation deps.kotlinCompileTesting
     testImplementation deps.kotlinCompileTestingKsp
     testImplementation project(':showkase-screenshot-testing-paparazzi')
-    // Force the version of paparazzi for Processor tests to be one that uses kotlin 1.7.10.
-    // This is because kotlin compiler testing library is not able to support Kotlin 1.7.20, which
-    // the latest version of Paparazzi uses. This was causing the following error when the tests
-    // from this module were executing
-    // e: java.lang.NoSuchMethodError: 'void org.jetbrains.kotlin.codegen.state.KotlinTypeMapper.<init>
-    // at com.google.devtools.ksp.processing.impl.ResolverImpl.<init>(ResolverImpl.kt:143)
-    // at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.doAnalysis(KotlinSymbolProcessingExtension.kt:188)
-    testImplementation "app.cash.paparazzi:paparazzi:1.1.0"
+    testImplementation deps.test.paparazzi
 }
 
 // Needed for Java17 otherwise these tests failed to run locally.


### PR DESCRIPTION
Was going to do a release so figured I'll just upgrade it once more to get it to more current versions

Kotlin -> 1.9.23
KSP -> 1.9.23-1.0.20
Compose Compiler -> 1.5.13
Kotlin Compiler Testing -> 0.4.1