### PR TITLE
Add workaround to prevent emulator from getting stuck on CI jobs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -131,8 +131,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            ./gradlew connectedCheck --no-daemon --stacktrace
+            adb devices -l
             bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"
+            ./gradlew connectedCheck --no-daemon --stacktrace
+           
 
       - name: Start emulator and run UI Tests w/ KSP
         uses: reactivecircus/android-emulator-runner@v2
@@ -142,8 +144,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
+            adb devices -l
+            bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"     
             ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true
-            bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"      
 
       - name: Run Screenshot Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -130,7 +130,9 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedCheck --no-daemon --stacktrace
+          script: |
+            ./gradlew connectedCheck --no-daemon --stacktrace
+            bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"
 
       - name: Start emulator and run UI Tests w/ KSP
         uses: reactivecircus/android-emulator-runner@v2
@@ -139,7 +141,9 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true
+          script: |
+            ./gradlew connectedCheck --no-daemon --stacktrace -PuseKsp=true
+            bash --noprofile --norc -eo pipefail "${{ steps.script.outputs.file }}"      
 
       - name: Run Screenshot Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -91,6 +91,28 @@ jobs:
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}
 
+      - name: Prepare script to run
+        id: script
+        env:
+          SCRIPT: |
+            # Workaround for https://github.com/ReactiveCircus/android-emulator-runner/issues/373
+            pre_terminate_crashpad() {
+              # For some reason pgrep/pkill sees only crashpad_handle, not crashpad_handler,
+              # but it's definitely called ${ANDROID_HOME}/emulator/crashpad_handler.
+            
+              # Best-effort gracefully terminate all crashpad_handler processes.
+              pkill --exact --echo --signal SIGTERM crashpad_handle || return
+              sleep 10
+              pkill --exact --echo --signal SIGKILL crashpad_handle || return
+            }
+            trap pre_terminate_crashpad EXIT
+            
+            ${{ inputs.script }}
+        run: |
+          script_file="${RUNNER_TEMP}/reactivecircus-android-emulator-runner-prepared-script.sh"
+          echo "${SCRIPT}" > "${script_file}"
+          echo "file=${script_file}" >> "${GITHUB_OUTPUT}"
+
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Inspired by the solution here - https://github.com/TWiStErRob/github-workflows/pull/44