### PR TITLE
Shorten generated Paparazzi filenames

### DIFF
--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/PaparazziShowkaseScreenshotTestWriter.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/PaparazziShowkaseScreenshotTestWriter.kt
@@ -22,7 +22,7 @@ class PaparazziShowkaseScreenshotTestWriter(private val environment: XProcessing
         rootModulePackageName: String,
         testClassName: String
     ) {
-        val showkaseScreenshotTestClassName = "${testClassName}_PaparazziShowkaseTest"
+        val showkaseScreenshotTestClassName = "${testClassName}Impl"
         val fileBuilder = getFileBuilder(screenshotTestPackageName, showkaseScreenshotTestClassName)
         fileBuilder
             .addImport(rootModulePackageName, "getMetadata")

--- a/showkase-screenshot-testing-paparazzi/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/PaparazziShowkaseScreenshotTest.kt
+++ b/showkase-screenshot-testing-paparazzi/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/PaparazziShowkaseScreenshotTest.kt
@@ -102,7 +102,11 @@ interface PaparazziShowkaseScreenshotTest {
         direction: LayoutDirection,
         mode: PaparazziShowkaseUIMode
     ) {
-        paparazzi.snapshot(name = testPreview.toString()) {
+        paparazzi.snapshot(
+            // No need to pass name here as the Paparazzi instance already uses the
+            // containing test class name, test function, and function arguments to generate
+            // a unique screenshot file name.
+        ) {
             val lifecycleOwner = LocalLifecycleOwner.current
             val configuration = if (mode == PaparazziShowkaseUIMode.DARK) {
                 Configuration(LocalConfiguration.current).apply {


### PR DESCRIPTION
By default, Paparazzi concatenates the package name of the test class, the test class name, the test function name, the test function parameters, and the `name` value passed to the `snapshot()` function. On some systems this can cause a `java.io.FileNotFoundException (File name too long)`.

This is a commonly encountered issue and an [issue has been filed against the Paparazzi repo](https://github.com/cashapp/paparazzi/issues/1085) to allow overriding this default filename logic. Until then, we can take smaller measures to shorten the file name:

1. Use an "Impl" suffix for the generated concrete test class
2. Don't pass a `name` argument to `snapshot()`, which results in redundancy. For example, instead of
```
com.myapplication.test.compose.paparazzi_PaparazziShowkaseScreenshotTest_PaparazziShowkaseTest_test_previews[GroupName**ComponentName**StyleName,Pixel5,Ltr,DEFAULT]_GroupName**ComponentName**StyleName.temp.png
```
this will now generate
```
com.myapplication.test.compose.paparazzi_PaparazziShowkaseScreenshotTestImpl_test_previews[GroupName**ComponentName**StyleName,Pixel5,Ltr,DEFAULT].temp.png
```