### PR TITLE
Add a `Skip` option to screenshot configuration

### DIFF
--- a/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ScreenshotConfig.kt
+++ b/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ScreenshotConfig.kt
@@ -25,4 +25,6 @@ sealed interface ScreenshotConfig {
     data class MultipleImagesAtOffsets(
         val offsetMillis: List<Int>,
     ) : ScreenshotConfig
+
+    object Skip : ScreenshotConfig
 }

--- a/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ShowkaseComposable.kt
+++ b/showkase-annotation/src/main/java/com/airbnb/android/showkase/annotation/ShowkaseComposable.kt
@@ -138,5 +138,10 @@ enum class ScreenshotCaptureType {
      *
      * NOTE: This isn't working currently in Paparazzi, see https://github.com/cashapp/paparazzi/pull/1645.
      */
-    MultipleImagesAtOffsets
+    MultipleImagesAtOffsets,
+
+    /**
+     * Don't take screenshots of this Composable.
+     */
+    Skip
 }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/models/ShowkaseMetadata.kt
@@ -11,6 +11,10 @@ import androidx.room.compiler.processing.compat.XConverters.toJavac
 import com.airbnb.android.showkase.annotation.ScreenshotCaptureConfig
 import com.airbnb.android.showkase.annotation.ScreenshotCaptureType
 import com.airbnb.android.showkase.annotation.ScreenshotConfig
+import com.airbnb.android.showkase.annotation.ScreenshotConfig.MultipleImagesAtOffsets
+import com.airbnb.android.showkase.annotation.ScreenshotConfig.SingleAnimatedImage
+import com.airbnb.android.showkase.annotation.ScreenshotConfig.SingleStaticImage
+import com.airbnb.android.showkase.annotation.ScreenshotConfig.Skip
 import com.airbnb.android.showkase.annotation.ShowkaseColor
 import com.airbnb.android.showkase.annotation.ShowkaseComposable
 import com.airbnb.android.showkase.annotation.ShowkaseMultiPreviewCodegenMetadata
@@ -65,7 +69,7 @@ internal sealed class ShowkaseMetadata {
         val isDefaultStyle: Boolean = false,
         val tags: List<String> = emptyList(),
         val extraMetadata: List<String> = emptyList(),
-        val screenshotConfig: ScreenshotConfig = ScreenshotConfig.SingleStaticImage,
+        val screenshotConfig: ScreenshotConfig = SingleStaticImage,
     ) : ShowkaseMetadata()
 
     data class Color(
@@ -185,15 +189,17 @@ private fun screenshotConfigFrom(annotation: XAnnotation): ScreenshotConfig {
         screenshotCaptureConfig.getAsIntList(ScreenshotCaptureConfig::offsetsMillis.name)
 
     val screenshotConfig = when (screenshotCaptureType) {
-        ScreenshotCaptureType.SingleStaticImage -> ScreenshotConfig.SingleStaticImage
-        ScreenshotCaptureType.MultipleImagesAtOffsets -> ScreenshotConfig.MultipleImagesAtOffsets(
+        ScreenshotCaptureType.SingleStaticImage -> SingleStaticImage
+        ScreenshotCaptureType.MultipleImagesAtOffsets -> MultipleImagesAtOffsets(
             offsetMillis = animationOffsetsMillis,
         )
 
-        ScreenshotCaptureType.SingleAnimatedImage -> ScreenshotConfig.SingleAnimatedImage(
+        ScreenshotCaptureType.SingleAnimatedImage -> SingleAnimatedImage(
             durationMillis = gifDurationMillis,
             framerate = gifFramerate,
         )
+
+        ScreenshotCaptureType.Skip -> Skip
     }
     return screenshotConfig
 }

--- a/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
+++ b/showkase-processor/src/main/java/com/airbnb/android/showkase/processor/writer/WriterUtils.kt
@@ -185,6 +185,7 @@ fun screenshotConfigCodeBlock(config: ScreenshotConfig): CodeBlock = when (confi
             config.offsetMillis.joinToString(", "),
         )
     }
+    ScreenshotConfig.Skip -> CodeBlock.of("%T", ScreenshotConfig.Skip::class)
 }
 
 @Suppress("LongParameterList")

--- a/showkase-screenshot-testing-paparazzi-sample/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/sample/SkipScreenshots.kt
+++ b/showkase-screenshot-testing-paparazzi-sample/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/sample/SkipScreenshots.kt
@@ -1,0 +1,16 @@
+package com.airbnb.android.showkase.screenshot.testing.paparazzi.sample
+
+import androidx.compose.runtime.Composable
+import com.airbnb.android.showkase.annotation.ScreenshotCaptureConfig
+import com.airbnb.android.showkase.annotation.ScreenshotCaptureType
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+
+@ShowkaseComposable(
+    name = "SkipScreenshots",
+    defaultStyle = true,
+    screenshotCaptureConfig = ScreenshotCaptureConfig(type = ScreenshotCaptureType.Skip),
+)
+@Composable
+fun SkipScreenshotsPreview() {
+    throw IllegalStateException("Intentional crash to fail if screenshot taken")
+}

--- a/showkase-screenshot-testing-paparazzi/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/PaparazziShowkaseScreenshotTest.kt
+++ b/showkase-screenshot-testing-paparazzi/src/main/java/com/airbnb/android/showkase/screenshot/testing/paparazzi/PaparazziShowkaseScreenshotTest.kt
@@ -124,6 +124,7 @@ interface PaparazziShowkaseScreenshotTest {
                  end = captureType.durationMillis.toLong(),
                  fps = captureType.framerate
              )
+             ScreenshotConfig.Skip -> return
          }
     }
 


### PR DESCRIPTION
This can be useful for excluding certain annotated previews from being screenshot tested, for example when `layoutlib` cannot correctly render the contents, but when it's still useful to see the component in the Showkase browser.