### PR TITLE
Delete generated BuildTypeAttr in module file to not force the build type to app consumer

### DIFF
--- a/showkase-screenshot-testing-paparazzi/build.gradle
+++ b/showkase-screenshot-testing-paparazzi/build.gradle
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
     id 'com.android.library'
@@ -86,5 +86,5 @@ dependencies {
 }
 
 mavenPublishing {
-    configure(new AndroidMultiVariantLibrary(true, true))
+    configure(new AndroidSingleVariantLibrary("release", true, true))
 }

--- a/showkase-screenshot-testing-shot/build.gradle
+++ b/showkase-screenshot-testing-shot/build.gradle
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
     id 'com.android.library'
@@ -63,5 +63,5 @@ dependencies {
 }
 
 mavenPublishing {
-    configure(new AndroidMultiVariantLibrary(true, true))
+    configure(new AndroidSingleVariantLibrary("release", true, true))
 }

--- a/showkase-screenshot-testing/build.gradle
+++ b/showkase-screenshot-testing/build.gradle
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
@@ -59,5 +59,5 @@ dependencies {
 }
 
 mavenPublishing {
-    configure(new AndroidMultiVariantLibrary(true, true))
+    configure(new AndroidSingleVariantLibrary("release", true, true))
 }

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.AndroidMultiVariantLibrary
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
     id 'com.android.library'
@@ -67,5 +67,5 @@ dependencies {
 }
 
 mavenPublishing {
-    configure(new AndroidMultiVariantLibrary(true, true))
+    configure(new AndroidSingleVariantLibrary("release", true, true))
 }


### PR DESCRIPTION
Fix [#416](https://github.com/airbnb/Showkase/issues/416), [#274](https://github.com/airbnb/Showkase/issues/274).

Due to commit [e7f105f](https://github.com/airbnb/Showkase/compare/1.0.4...1.0.5) the module file generated by the plugin [gradle-maven-publish-plugin](https://github.com/vanniktech/gradle-maven-publish-plugin?tab=readme-ov-file) contains `com.android.build.api.attributes.BuildTypeAttr` attribute. This attribute force consumer of the library to use only the build types specified by the attribute: "debug" and "release". 
See this [medium article](https://proandroiddev.com/fixing-dependency-metadata-in-gradle-65fd86abe4e1), if you want to have more details on the issue.

Reproduction case is to create an app with a specific buildTypes (not debug and release) and try to compile. Example on [ReproProjectShowkase](https://github.com/DevHugo/ReproProjectShowkase) with command `./gradlew clean assemblePaid --rerun-tasks --no-configuration-cache`

Before the PR, the module file look like [this](https://repo1.maven.org/maven2/com/airbnb/android/showkase/1.0.5/showkase-1.0.5.module).
```
 "variants": [
  {
    "name": "debugVariantMavenApiPublication",
    "attributes": {
      "com.android.build.api.attributes.BuildTypeAttr": "debug"
      (other attrs redacted for clarity ...)
    },
  }
]

```

After this PR, the module generated by the plugin should look like the 1.0.4 version module file. You can attest that by checking the diff between the 1.0.4 version and the fixed module file 1.0.5: [https://www.diffchecker.com/dn2JxDwe/](https://www.diffchecker.com/dn2JxDwe/) (external website diffchecker.com). 

It also avoid publishing debug artefact, that was not needed. See this [PR](https://github.com/airbnb/Showkase/pull/291) and [issue 274](https://github.com/airbnb/Showkase/issues/274).

You can find documentation on [AndroidSingleVariantLibrary](https://vanniktech.github.io/gradle-maven-publish-plugin/what/#android-library-single-variant) or [source code](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/plugin/src/main/kotlin/com/vanniktech/maven/publish/Platform.kt#L147), if you want to deep-dive a little. 

Non regression test done: see that it works in the demo project [ReproProjectShowkase](https://github.com/DevHugo/ReproProjectShowkase) and test the sample app.