### PR TITLE
Fix crash missing material icons dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
             'composeActivity'        : '1.9.0',
             'composeConstraintLayout': '1.0.1',
             'composeNavigation'      : '2.7.7',
+            'materialIconsCore'      : '1.7.3',
             'detekt'                 : '1.23.6',
             'espresso'               : '3.2.0',
             'gradle'                 : '8.9.1',
@@ -46,6 +47,7 @@ buildscript {
                     'toolingPreview'    : "androidx.compose.ui:ui-tooling-preview:${versions.compose}",
                     'layout'            : "androidx.compose.foundation:foundation-layout:${versions.compose}",
                     'material'          : "androidx.compose.material:material:${versions.compose}",
+                    'materialIconsCore' : "org.jetbrains.compose.material:material-icons-core:${versions.materialIconsCore}",
                     'savedInstanceState': "androidx.compose.runtime:runtime-saveable:${versions.compose}",
                     'uiTest'            : "androidx.compose.ui:ui-test-junit4:${versions.compose}",
                     'uiLiveData'        : "androidx.compose.runtime:runtime-livedata:${versions.compose}"

--- a/showkase/build.gradle
+++ b/showkase/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     implementation deps.compose.tooling
     implementation deps.compose.layout
     implementation deps.compose.material
+
+    implementation deps.compose.materialIconsCore
 }
 
 mavenPublishing {


### PR DESCRIPTION
Fix #424

Compose Material library moving the Icons set into a separate Gradle dependency starting in newer BOM versions. See: https://kotlinlang.org/docs/multiplatform/whats-new-compose-180.html#implicit-dependency-on-material-icons-core-removed